### PR TITLE
31 8 3 display selected background in canvas

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -13,7 +13,13 @@ const Layout = (props: Props) => {
   return (
     <>
       <Header />
-      <Box display="flex" width="100%" p={0} sx={{ flexDirection: 'row' }}>
+      <Box
+        display="flex"
+        height="calc(100vh - 50px)"
+        width="100%"
+        p={0}
+        sx={{ flexDirection: 'row' }}
+      >
         <main
           style={{
             width: '100%',

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -18,16 +18,15 @@ const Sidebar = () => {
   return (
     <>
       {/* Button when drawer is closed */}
-      <Box bgcolor="#FBFBFB" width={5} sx={{ borderLeft: '1px solid #F8F8F8' }}>
-        <SidebarToggleButton onClick={() => setAnchor(true)} />
-      </Box>
+      {/* <Box bgcolor="#FBFBFB" width={5} sx={{ borderLeft: '1px solid #F8F8F8' }}> */}
+      <SidebarToggleButton onClick={() => setAnchor(true)} />
+      {/* </Box> */}
 
       {/* Drawer */}
       <Drawer
         anchor="right"
         open={anchor}
         onClose={toggleClose}
-        hideBackdrop
         sx={{
           mt: '50px',
           display: 'flex',
@@ -44,9 +43,7 @@ const Sidebar = () => {
       >
         <Box
           display="flex"
-          minWidth={295}
-          width={295}
-          sx={{ flexDirection: 'row' }}
+          sx={{ flexDirection: 'row', width: 295, minWidth: 295 }}
         >
           <Box
             bgcolor="transparent"

--- a/components/canvas/Test.tsx
+++ b/components/canvas/Test.tsx
@@ -1,9 +1,13 @@
-import { Image, Layer, Rect, Stage, Text } from 'react-konva';
+import { Container } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { Image as KonvaImg, Layer, Rect, Stage, Text } from 'react-konva';
 import useImage from 'use-image';
+import { useCanvas } from '../../context/CanvasContext';
 import { theme } from '../theme';
 
 // this component is just for testing - many values to be changed later
 function Test() {
+  const { background } = useCanvas();
   const [img1] = useImage(
     'https://firebasestorage.googleapis.com/v0/b/blueprint-298a2.appspot.com/o/posters%2Ffour%20coca%20cola%20bottles.jpg?alt=media&token=7e1d8a77-358c-4a19-9742-1e91e09de6e2'
   );
@@ -12,106 +16,128 @@ function Test() {
     'https://firebasestorage.googleapis.com/v0/b/blueprint-298a2.appspot.com/o/posters%2Fmilky%20way%20with%20mountains.jpeg?alt=media&token=ead8bbfe-f1e5-423d-89ee-aab6847ebac8'
   );
 
+  const stageCanvasRef = useRef<HTMLDivElement>(null);
+
+  const [dimensions, setDimensions] = useState({ height: 100, width: 100 });
+
+  useEffect(() => {
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const element = entry.target as HTMLElement;
+        const style = window.getComputedStyle(element);
+        const paddingLeft = parseInt(style.paddingLeft || '0', 10);
+        const paddingRight = parseInt(style.paddingRight || '0', 10);
+        const rect = element.getBoundingClientRect();
+        const height = Math.floor(rect.height);
+        const width = Math.floor(rect.width - paddingLeft - paddingRight);
+        setDimensions({ height, width });
+      }
+    });
+
+    if (stageCanvasRef.current) {
+      observer.observe(stageCanvasRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return (
-    <Stage
-      width={window.innerWidth}
-      height={window.innerHeight}
-      style={{
-        maxHeight: 'calc(100vh - 50px)',
-        maxWidth: '100vw',
-        overflow: 'clip',
-      }}
-    >
-      <Layer>
-        <Text
-          text="Close the drawer in order to be able to drag the frame!"
-          x={50}
-          y={20}
-          fill="brown"
-          fontSize={20}
-          fontFamily={theme.typography.fontFamily}
-          fontVariant="bold"
-        />
-      </Layer>
-      <Layer draggable>
-        <Rect
-          x={20}
-          y={50}
-          width={40 * 3.5}
-          height={50 * 3.5}
-          fill="black"
-          shadowBlur={15}
-          shadowColor="black"
-          shadowOpacity={0.5}
-          shadowOffset={{ x: 0, y: 5 }}
-        />
-        <Rect
-          x={20 + 10}
-          y={50 + 10}
-          width={40 * 3.5 - 20}
-          height={50 * 3.5 - 20}
-          fill="#f8f8f8"
-        />
-        <Image
-          image={img1}
-          alt="cola"
-          x={20 + 30}
-          y={50 + 30}
-          width={40 * 3.5 - 60}
-          height={50 * 3.5 - 60}
-          shadowBlur={1}
-          shadowColor="black"
-          shadowOpacity={0.6}
-          shadowOffset={{ x: 0, y: 0 }}
-        />
-        <Text
-          text="40x50"
-          x={(20 + 40 * 3.5) / 2.2}
-          y={50 + 50 * 3.5 + 10}
-          fontFamily={theme.typography.fontFamily}
-          fontSize={Number(theme.typography.body1.fontSize)}
-        />
-      </Layer>
-      <Layer draggable>
-        <Rect
-          x={100}
-          y={150}
-          width={50 * 3.5}
-          height={70 * 3.5}
-          fill="white"
-          shadowBlur={15}
-          shadowColor="black"
-          shadowOpacity={0.5}
-          shadowOffset={{ x: 0, y: 5 }}
-        />
-        <Rect
-          x={100 + 10}
-          y={150 + 10}
-          width={50 * 3.5 - 20}
-          height={70 * 3.5 - 20}
-          fill="#f8f8f8"
-        />
-        <Image
-          image={img2}
-          alt="cola"
-          x={100 + 30}
-          y={150 + 30}
-          width={50 * 3.5 - 60}
-          height={70 * 3.5 - 60}
-          shadowBlur={1}
-          shadowColor="black"
-          shadowOpacity={0.6}
-          shadowOffset={{ x: 0, y: 0 }}
-        />
-        <Text
-          text="50x70"
-          x={(100 + 50 * 3.5) / 1.62}
-          y={150 + 70 * 3.5 + 10}
-          fontFamily={theme.typography.fontFamily}
-          fontSize={Number(theme.typography.body1.fontSize)}
-        />
-      </Layer>
-    </Stage>
+    <Container sx={{ height: '100%' }} ref={stageCanvasRef}>
+      <Stage
+        height={dimensions.height}
+        width={dimensions.width}
+        style={{
+          backgroundImage: `url(${background})`,
+          maxHeight: dimensions.height,
+          maxWidth: dimensions.width,
+          overflow: 'hidden',
+          backgroundRepeat: 'no-repeat',
+          backgroundSize: 'contain',
+          backgroundPosition: 'center',
+        }}
+      >
+        <Layer draggable>
+          <Rect
+            x={20}
+            y={50}
+            width={40 * 3.5}
+            height={50 * 3.5}
+            fill="black"
+            shadowBlur={15}
+            shadowColor="black"
+            shadowOpacity={0.5}
+            shadowOffset={{ x: 0, y: 5 }}
+          />
+          <Rect
+            x={20 + 10}
+            y={50 + 10}
+            width={40 * 3.5 - 20}
+            height={50 * 3.5 - 20}
+            fill="#f8f8f8"
+          />
+          <KonvaImg
+            image={img1}
+            alt="cola"
+            x={20 + 30}
+            y={50 + 30}
+            width={40 * 3.5 - 60}
+            height={50 * 3.5 - 60}
+            shadowBlur={1}
+            shadowColor="black"
+            shadowOpacity={0.6}
+            shadowOffset={{ x: 0, y: 0 }}
+          />
+          <Text
+            text="40x50"
+            x={(20 + 40 * 3.5) / 2.2}
+            y={50 + 50 * 3.5 + 10}
+            fontFamily={theme.typography.fontFamily}
+            fontSize={Number(theme.typography.body1.fontSize)}
+          />
+        </Layer>
+        <Layer draggable>
+          <Rect
+            x={100}
+            y={150}
+            width={50 * 3.5}
+            height={70 * 3.5}
+            fill="white"
+            shadowBlur={15}
+            shadowColor="black"
+            shadowOpacity={0.5}
+            shadowOffset={{ x: 0, y: 5 }}
+          />
+          <Rect
+            x={100 + 10}
+            y={150 + 10}
+            width={50 * 3.5 - 20}
+            height={70 * 3.5 - 20}
+            fill="#f8f8f8"
+          />
+          <KonvaImg
+            image={img2}
+            alt="cola"
+            x={100 + 30}
+            y={150 + 30}
+            width={50 * 3.5 - 60}
+            height={70 * 3.5 - 60}
+            shadowBlur={1}
+            shadowColor="black"
+            shadowOpacity={0.6}
+            shadowOffset={{ x: 0, y: 0 }}
+          />
+          <Text
+            text="50x70"
+            x={(100 + 50 * 3.5) / 1.62}
+            y={150 + 70 * 3.5 + 10}
+            fontFamily={theme.typography.fontFamily}
+            fontSize={Number(theme.typography.body1.fontSize)}
+          />
+        </Layer>
+      </Stage>
+    </Container>
   );
 }
 

--- a/components/sidebar/BgSectionDetails.tsx
+++ b/components/sidebar/BgSectionDetails.tsx
@@ -104,7 +104,7 @@ const BgSectionDetails = () => {
                   position: 'relative',
                   height: 55,
                   boxShadow:
-                    background === index.toString() // TODO: change to ID
+                    background === bg.image
                       ? '0px 2px 5px rgba(0, 0, 0, 0.25)'
                       : null,
                 }}
@@ -112,12 +112,11 @@ const BgSectionDetails = () => {
                 <Image
                   width={65}
                   height={55}
-                  alt={bg.title} // TODO: change to title
+                  alt={bg.title}
                   src={bg.image}
-                  onClick={() => setBackground(index.toString())}
+                  onClick={() => setBackground(bg.image)}
                 />
-                {/* TODO: adjust logic - this should not be index but id */}
-                {background === index.toString() ? (
+                {background === bg.image ? (
                   <IconCheck
                     stroke={1}
                     color={theme.palette.primary.contrastText}
@@ -144,7 +143,7 @@ const BgSectionDetails = () => {
                   position: 'relative',
                   height: 55,
                   boxShadow:
-                    background === index.toString() // TODO: change to ID
+                    background === bg.image
                       ? '0px 2px 5px rgba(0, 0, 0, 0.25)'
                       : null,
                 }}
@@ -152,12 +151,11 @@ const BgSectionDetails = () => {
                 <Image
                   width={65}
                   height={55}
-                  alt={bg.title} // TODO: change to title
+                  alt={bg.title}
                   src={bg.image}
-                  onClick={() => setBackground(index.toString())}
+                  onClick={() => setBackground(bg.image)}
                 />
-                {/* TODO: adjust logic - this should not be index but id */}
-                {background === index.toString() ? (
+                {background === bg.image ? (
                   <IconCheck
                     stroke={1}
                     color={theme.palette.primary.contrastText}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import { collection, getDocs } from '@firebase/firestore';
-import { Container } from '@mui/material';
 import { Inter } from '@next/font/google';
 import { InferGetStaticPropsType } from 'next';
 import dynamic from 'next/dynamic';
@@ -54,11 +53,7 @@ export default function Home({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main>
-        <Container>
-          <Test />
-        </Container>
-      </main>
+      <Test />
     </>
   );
 }


### PR DESCRIPTION
- Made sidebar close when clicking on the canvas.
- When background is chosen in sidebar it sets that backgrounds url to the background-variable in the context.
- The canvas now has the background-variables url as image src - updates when choosing different image.
- Canvas is fully responsive, to make its future content responsive we can use the dimesion.width/height variables since they always update when the screen size changes. We'll make an additional ratio variable with them. **Since that is a different issue I'll skip it in this one**

![image](https://user-images.githubusercontent.com/94110161/210102476-6e38d87c-732e-4844-b053-82f2c093671e.png)
**Was not sure if you used the code i commented out for something important, so I kept it. It messed with the layout so thats why I removed it, sidebar still works as it should.**