### PR TITLE
#52 display poster in sidebar, #46 display poster in canvas, #53 apply passepartout

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { Box, Drawer, useMediaQuery } from '@mui/material';
-import { useState } from 'react';
 import { useSidebar } from '../context/SidebarContext';
 import SidebarToggleButton from './shared/SidebarToggleButton';
 import AddFrameButton from './sidebar/AddFrameButton';
@@ -10,22 +9,21 @@ import PosterSection from './sidebar/PosterSection';
 import { theme } from './theme';
 
 const Sidebar = () => {
-  const [anchor, setAnchor] = useState<boolean>(true);
-  const toggleClose = () => setAnchor(false);
+  const { anchorSidebar, setAnchorSidebar } = useSidebar();
+
+  const toggleClose = () => setAnchorSidebar(false);
   const { isEditingFrame } = useSidebar();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
     <>
       {/* Button when drawer is closed */}
-      {/* <Box bgcolor="#FBFBFB" width={5} sx={{ borderLeft: '1px solid #F8F8F8' }}> */}
-      <SidebarToggleButton onClick={() => setAnchor(true)} />
-      {/* </Box> */}
+      <SidebarToggleButton onClick={() => setAnchorSidebar(true)} />
 
       {/* Drawer */}
       <Drawer
         anchor="right"
-        open={anchor}
+        open={anchorSidebar}
         onClose={toggleClose}
         sx={{
           mt: '50px',

--- a/components/frames/PlainBlack.tsx
+++ b/components/frames/PlainBlack.tsx
@@ -3,10 +3,10 @@ import Image from 'next/image';
 import { useCanvas } from '../../context/CanvasContext';
 import monaLisa from '../../public/tempImages/mona-lisa.jpg';
 import PlainFrame from '../shared/PlainFrame';
-import { FrameDimension } from '../types';
+import { Dimension } from '../types';
 
 interface Props {
-  size: FrameDimension;
+  size: Dimension;
 }
 
 const PlainBlack = (props: Props) => {

--- a/components/frames/PlainMaple.tsx
+++ b/components/frames/PlainMaple.tsx
@@ -4,10 +4,10 @@ import { useCanvas } from '../../context/CanvasContext';
 import maple from '../../public/frameBg/maple-surface.jpg';
 import monaLisa from '../../public/tempImages/mona-lisa.jpg';
 import PlainFrame from '../shared/PlainFrame';
-import { FrameDimension } from '../types';
+import { Dimension } from '../types';
 
 interface Props {
-  size: FrameDimension;
+  size: Dimension;
 }
 
 const PlainMaple = (props: Props) => {

--- a/components/frames/PlainWalnut.tsx
+++ b/components/frames/PlainWalnut.tsx
@@ -4,10 +4,10 @@ import { useCanvas } from '../../context/CanvasContext';
 import walnut from '../../public/frameBg/walnut-surface.jpeg';
 import monaLisa from '../../public/tempImages/mona-lisa.jpg';
 import PlainFrame from '../shared/PlainFrame';
-import { FrameDimension } from '../types';
+import { Dimension } from '../types';
 
 interface Props {
-  size: FrameDimension;
+  size: Dimension;
 }
 
 const PlainWalnut = (props: Props) => {

--- a/components/frames/PlainWhite.tsx
+++ b/components/frames/PlainWhite.tsx
@@ -3,9 +3,10 @@ import Image from 'next/image';
 import { useCanvas } from '../../context/CanvasContext';
 import monaLisa from '../../public/tempImages/mona-lisa.jpg';
 import PlainFrame from '../shared/PlainFrame';
-import { FrameDimension } from '../types';
+import { Dimension } from '../types';
+
 interface Props {
-  size: FrameDimension;
+  size: Dimension;
 }
 
 const PlainWhite = (props: Props) => {

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -19,7 +19,7 @@ const CanvasFrame = (props: Props) => {
   const dimension = frameDimensions[props.item.frame.size];
   const match = allFrames.filter((frame) => frame.id === props.item.frame.id);
 
-  const [poster] = useImage(props.item.poster.src);
+  const [poster] = useImage(props.item.poster.image);
   const [maple] = useImage(
     'https://firebasestorage.googleapis.com/v0/b/blueprint-298a2.appspot.com/o/frames%2Fmaple-surface.jpg?alt=media&token=4d386205-d4fa-4531-b801-543d95101a98'
   );

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -79,8 +79,16 @@ const CanvasFrame = (props: Props) => {
             alt={match[0].title}
             x={pos().x}
             y={pos().y}
-            width={dimension.width * 3.5}
-            height={dimension.height * 3.5}
+            width={
+              props.item.poster.isPortrait
+                ? dimension.width * 3.5
+                : dimension.height * 3.5
+            }
+            height={
+              props.item.poster.isPortrait
+                ? dimension.height * 3.5
+                : dimension.width * 3.5
+            }
             shadowBlur={15}
             shadowColor="#000"
             shadowOpacity={0.5}
@@ -90,8 +98,16 @@ const CanvasFrame = (props: Props) => {
           <Rect
             x={pos().x}
             y={pos().y}
-            width={dimension.width * 3.5}
-            height={dimension.height * 3.5}
+            width={
+              props.item.poster.isPortrait
+                ? dimension.width * 3.5
+                : dimension.height * 3.5
+            }
+            height={
+              props.item.poster.isPortrait
+                ? dimension.height * 3.5
+                : dimension.width * 3.5
+            }
             fill={frameColor()}
             shadowBlur={15}
             shadowColor="#000"
@@ -105,8 +121,16 @@ const CanvasFrame = (props: Props) => {
           alt="cola"
           x={pos().x + frameBorder()}
           y={pos().y + frameBorder()}
-          width={dimension.width * 3.5 - frameBorder() * 2}
-          height={dimension.height * 3.5 - frameBorder() * 2}
+          width={
+            props.item.poster.isPortrait
+              ? dimension.width * 3.5 - frameBorder() * 2
+              : dimension.height * 3.5 - frameBorder() * 2
+          }
+          height={
+            props.item.poster.isPortrait
+              ? dimension.height * 3.5 - frameBorder() * 2
+              : dimension.width * 3.5 - frameBorder() * 2
+          }
         />
         {props.item.withPassepartout ? (
           <>
@@ -116,28 +140,51 @@ const CanvasFrame = (props: Props) => {
                 x={pos().x + frameBorder()}
                 y={pos().y + frameBorder()}
                 width={passepartout() - frameBorder()}
-                height={dimension.height * 3.5 - frameBorder() * 2}
+                height={
+                  props.item.poster.isPortrait
+                    ? dimension.height * 3.5 - frameBorder() * 2
+                    : dimension.width * 3.5 - frameBorder() * 2
+                }
                 fill="#f8f8f8"
               />
               <Rect
-                x={pos().x + dimension.width * 3.5 - passepartout()}
+                x={
+                  props.item.poster.isPortrait
+                    ? pos().x + dimension.width * 3.5 - passepartout()
+                    : pos().x + dimension.height * 3.5 - passepartout()
+                }
                 y={pos().y + frameBorder()}
                 width={passepartout() - frameBorder()}
-                height={dimension.height * 3.5 - frameBorder() * 2}
+                height={
+                  props.item.poster.isPortrait
+                    ? dimension.height * 3.5 - frameBorder() * 2
+                    : dimension.width * 3.5 - frameBorder() * 2
+                }
                 fill="#f8f8f8"
               />
               <Rect
                 x={pos().x + frameBorder()}
                 y={pos().y + frameBorder()}
-                width={dimension.width * 3.5 - frameBorder() * 2}
+                width={
+                  props.item.poster.isPortrait
+                    ? dimension.width * 3.5 - frameBorder() * 2
+                    : dimension.height * 3.5 - frameBorder() * 2
+                }
                 height={passepartout() * 1.1 - frameBorder()}
                 fill="#f8f8f8"
               />
-
               <Rect
                 x={pos().x + frameBorder()}
-                y={pos().y + dimension.height * 3.5 - passepartout() * 1.1}
-                width={dimension.width * 3.5 - frameBorder() * 2}
+                y={
+                  props.item.poster.isPortrait
+                    ? pos().y + dimension.height * 3.5 - passepartout() * 1.1
+                    : pos().y + dimension.width * 3.5 - passepartout() * 1.1
+                }
+                width={
+                  props.item.poster.isPortrait
+                    ? dimension.width * 3.5 - frameBorder() * 2
+                    : dimension.height * 3.5 - frameBorder() * 2
+                }
                 height={passepartout() * 1.1 - frameBorder()}
                 fill="#f8f8f8"
               />
@@ -148,7 +195,11 @@ const CanvasFrame = (props: Props) => {
                 x={pos().x + passepartout()}
                 y={pos().y + passepartout() * 1.1 + 1}
                 width={1}
-                height={dimension.height * 3.5 - passepartout() * 1.1 * 2 - 1}
+                height={
+                  props.item.poster.isPortrait
+                    ? dimension.height * 3.5 - passepartout() * 1.1 * 2 - 1
+                    : dimension.width * 3.5 - passepartout() * 1.1 * 2 - 1
+                }
                 fill="#eee"
                 shadowBlur={0.25}
                 shadowColor="#000"
@@ -156,10 +207,18 @@ const CanvasFrame = (props: Props) => {
                 shadowOffset={{ x: 0, y: 0 }}
               />
               <Rect
-                x={pos().x + dimension.width * 3.5 - passepartout()}
+                x={
+                  props.item.poster.isPortrait
+                    ? pos().x + dimension.width * 3.5 - passepartout()
+                    : pos().x + dimension.height * 3.5 - passepartout()
+                }
                 y={pos().y + passepartout() * 1.1 + 1}
                 width={1}
-                height={dimension.height * 3.5 - passepartout() * 1.1 * 2 - 1}
+                height={
+                  props.item.poster.isPortrait
+                    ? dimension.height * 3.5 - passepartout() * 1.1 * 2 - 1
+                    : dimension.width * 3.5 - passepartout() * 1.1 * 2 - 1
+                }
                 fill="#eee"
                 shadowBlur={0.25}
                 shadowColor="#000"
@@ -169,7 +228,11 @@ const CanvasFrame = (props: Props) => {
               <Rect
                 x={pos().x + passepartout()}
                 y={pos().y + passepartout() * 1.1}
-                width={dimension.width * 3.5 - passepartout() * 2 + 1}
+                width={
+                  props.item.poster.isPortrait
+                    ? dimension.width * 3.5 - passepartout() * 2 + 1
+                    : dimension.height * 3.5 - passepartout() * 2 + 1
+                }
                 height={1}
                 fill="#ddd"
                 shadowBlur={0.5}
@@ -179,8 +242,16 @@ const CanvasFrame = (props: Props) => {
               />
               <Rect
                 x={pos().x + passepartout()}
-                y={pos().y + dimension.height * 3.5 - passepartout() * 1.1}
-                width={dimension.width * 3.5 - passepartout() * 2 + 1}
+                y={
+                  props.item.poster.isPortrait
+                    ? pos().y + dimension.height * 3.5 - passepartout() * 1.1
+                    : pos().y + dimension.width * 3.5 - passepartout() * 1.1
+                }
+                width={
+                  props.item.poster.isPortrait
+                    ? dimension.width * 3.5 - passepartout() * 2 + 1
+                    : dimension.height * 3.5 - passepartout() * 2 + 1
+                }
                 height={1}
                 fill="#fff"
               />
@@ -192,7 +263,11 @@ const CanvasFrame = (props: Props) => {
           x={pos().x + frameBorder()}
           y={pos().y + frameBorder() + 1}
           width={1}
-          height={dimension.height * 3.5 - frameBorder() * 2 - 1}
+          height={
+            props.item.poster.isPortrait
+              ? dimension.height * 3.5 - frameBorder() * 2 - 1
+              : dimension.width * 3.5 - frameBorder() * 2 - 1
+          }
           fill="#eee"
           shadowBlur={3}
           shadowColor="#ddd"
@@ -200,10 +275,18 @@ const CanvasFrame = (props: Props) => {
           shadowOffset={{ x: 2, y: 0 }}
         />
         <Rect
-          x={pos().x + dimension.width * 3.5 - frameBorder()}
+          x={
+            props.item.poster.isPortrait
+              ? pos().x + dimension.width * 3.5 - frameBorder()
+              : pos().x + dimension.height * 3.5 - frameBorder()
+          }
           y={pos().y + frameBorder() + 1}
           width={1}
-          height={dimension.height * 3.5 - frameBorder() * 2 - 1}
+          height={
+            props.item.poster.isPortrait
+              ? dimension.height * 3.5 - frameBorder() * 2 - 1
+              : dimension.width * 3.5 - frameBorder() * 2 - 1
+          }
           fill="#eee"
           shadowBlur={3}
           shadowColor="#ddd"
@@ -213,7 +296,11 @@ const CanvasFrame = (props: Props) => {
         <Rect
           x={pos().x + frameBorder()}
           y={pos().y + frameBorder()}
-          width={dimension.width * 3.5 - frameBorder() * 2 + 1}
+          width={
+            props.item.poster.isPortrait
+              ? dimension.width * 3.5 - frameBorder() * 2 + 1
+              : dimension.height * 3.5 - frameBorder() * 2 + 1
+          }
           height={1}
           fill="#ddd"
           shadowBlur={13}
@@ -223,16 +310,32 @@ const CanvasFrame = (props: Props) => {
         />
         <Rect
           x={pos().x + frameBorder()}
-          y={pos().y + dimension.height * 3.5 - frameBorder()}
-          width={dimension.width * 3.5 - frameBorder() * 2 + 1}
+          y={
+            props.item.poster.isPortrait
+              ? pos().y + dimension.height * 3.5 - frameBorder()
+              : pos().y + dimension.width * 3.5 - frameBorder()
+          }
+          width={
+            props.item.poster.isPortrait
+              ? dimension.width * 3.5 - frameBorder() * 2 + 1
+              : dimension.height * 3.5 - frameBorder() * 2 + 1
+          }
           height={1}
           fill="#fff"
           opacity={0.5}
         />
         <Text
           text={dimension.width + 'x' + dimension.height}
-          x={pos().x + (dimension.width * 3.5) / 2 - 20}
-          y={pos().y + dimension.height * 3.5 + 10}
+          x={
+            props.item.poster.isPortrait
+              ? pos().x + (dimension.width * 3.5) / 2 - 20
+              : pos().x + (dimension.height * 3.5) / 2 - 20
+          }
+          y={
+            props.item.poster.isPortrait
+              ? pos().y + dimension.height * 3.5 + 10
+              : pos().y + dimension.width * 3.5 + 10
+          }
           fontFamily={theme.typography.fontFamily}
           fontSize={Number(theme.typography.body1.fontSize)}
         />

--- a/components/shared/PlainFrame.tsx
+++ b/components/shared/PlainFrame.tsx
@@ -2,13 +2,13 @@ import { Box } from '@mui/material';
 import Image, { StaticImageData } from 'next/image';
 import { ReactNode } from 'react';
 import { frameDimensions } from '../../data/frameData';
-import { FrameDimension } from '../types';
+import { Dimension } from '../types';
 
 interface Props {
   isWhiteFrame?: boolean;
   bgColor?: string;
   bgImg?: { src: StaticImageData; alt: string };
-  size: FrameDimension;
+  size: Dimension;
   children: ReactNode;
 }
 

--- a/components/shared/SidebarAccordion.tsx
+++ b/components/shared/SidebarAccordion.tsx
@@ -7,8 +7,8 @@ import {
 import { IconChevronUp } from '@tabler/icons';
 import { ReactNode } from 'react';
 import { useSidebar } from '../../context/SidebarContext';
+import { sidebarSections } from '../../lib/valSchemas';
 import { theme } from '../theme';
-import { sidebarSections } from '../types';
 
 interface Props {
   panel: string;

--- a/components/shared/SidebarAccordion.tsx
+++ b/components/shared/SidebarAccordion.tsx
@@ -61,6 +61,7 @@ const SidebarAccordion = (props: Props) => {
           maxWidth: 280,
           minHeight: 'calc(100vh - 200px)',
           maxHeight: 'calc(100vh - 200px)',
+          height: 'calc(100vh - 200px)',
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/components/shared/SidebarToggleButton.tsx
+++ b/components/shared/SidebarToggleButton.tsx
@@ -8,31 +8,33 @@ interface Props {
 
 const SidebarToggleButton = (props: Props) => {
   return (
-    <Box
-      bgcolor="#F8F8F8"
-      position="absolute"
-      width={15}
-      height={110}
-      onClick={props.onClick}
-      display="flex"
-      sx={{
-        right: props.isToClose ? null : 6,
-        left: props.isToClose ? 0 : null,
-        mt: props.isToClose ? null : '25px',
-        top: '50%',
-        zIndex: 999,
-        border: '1px solid #F8F8F8',
-        borderRadius: '10px 0 0 10px',
-        transform: 'translateY(-50%)',
-        placeItems: 'center',
-        cursor: 'pointer',
-      }}
-    >
-      {props.isToClose ? (
-        <IconChevronRight color="#898989" />
-      ) : (
-        <IconChevronLeft color="#898989" />
-      )}
+    <Box bgcolor="#FBFBFB" width={5} sx={{ borderLeft: '1px solid #F8F8F8' }}>
+      <Box
+        bgcolor="#F8F8F8"
+        position="absolute"
+        width={15}
+        height={110}
+        onClick={props.onClick}
+        display="flex"
+        sx={{
+          right: props.isToClose ? null : 6,
+          left: props.isToClose ? 0 : null,
+          mt: props.isToClose ? null : '25px',
+          top: '50%',
+          zIndex: 999,
+          border: '1px solid #F8F8F8',
+          borderRadius: '10px 0 0 10px',
+          transform: 'translateY(-50%)',
+          placeItems: 'center',
+          cursor: 'pointer',
+        }}
+      >
+        {props.isToClose ? (
+          <IconChevronRight color="#898989" />
+        ) : (
+          <IconChevronLeft color="#898989" />
+        )}
+      </Box>
     </Box>
   );
 };

--- a/components/sidebar/AddFrameButton.tsx
+++ b/components/sidebar/AddFrameButton.tsx
@@ -1,10 +1,21 @@
 import { Box, Typography } from '@mui/material';
 import { IconPlus } from '@tabler/icons';
+import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
+import { sidebarSections } from '../../lib/valSchemas';
 import { theme } from '../theme';
 
 const AddFrameButton = () => {
-  const { setIsEditingFrame } = useSidebar();
+  const { setIsEditingFrame, setExpandedAccordion } = useSidebar();
+  const { background } = useCanvas();
+
+  const handleClick = () => {
+    if (background) {
+      setIsEditingFrame(true);
+      setExpandedAccordion(sidebarSections[1]);
+    }
+    setIsEditingFrame(true);
+  };
   return (
     <Box
       bgcolor="#3A3335"
@@ -20,7 +31,7 @@ const AddFrameButton = () => {
         },
       }}
       height={40}
-      onClick={() => setIsEditingFrame(true)} // TODO: add function
+      onClick={handleClick}
     >
       <IconPlus size={16} stroke={2} />
       <Typography variant="body1">Add Frame</Typography>

--- a/components/sidebar/BgSection.tsx
+++ b/components/sidebar/BgSection.tsx
@@ -1,9 +1,9 @@
 import { useMediaQuery } from '@mui/material';
 import { useSidebar } from '../../context/SidebarContext';
+import { sidebarSections } from '../../lib/valSchemas';
 import MobileSidebarContainer from '../shared/MobileSidebarContainer';
 import SidebarAccordion from '../shared/SidebarAccordion';
 import { theme } from '../theme';
-import { sidebarSections } from '../types';
 import BgSectionDetails from './BgSectionDetails';
 
 const BgSection = () => {

--- a/components/sidebar/BgSectionDetails.tsx
+++ b/components/sidebar/BgSectionDetails.tsx
@@ -80,7 +80,6 @@ const BgSectionDetails = () => {
           justifyContent: 'center',
           my: 2,
           overflowY: 'scroll',
-
           '&::-webkit-scrollbar': {
             width: '0.4em',
           },

--- a/components/sidebar/FrameSection.tsx
+++ b/components/sidebar/FrameSection.tsx
@@ -1,9 +1,9 @@
 import { useMediaQuery } from '@mui/material';
 import { useSidebar } from '../../context/SidebarContext';
+import { sidebarSections } from '../../lib/valSchemas';
 import MobileSidebarContainer from '../shared/MobileSidebarContainer';
 import SidebarAccordion from '../shared/SidebarAccordion';
 import { theme } from '../theme';
-import { sidebarSections } from '../types';
 import FrameSectionDetails from './FrameSectionDetails';
 
 const FrameSection = () => {

--- a/components/sidebar/FrameSectionDetails.tsx
+++ b/components/sidebar/FrameSectionDetails.tsx
@@ -58,7 +58,7 @@ const FrameSectionDetails = () => {
           <Switch
             checked={withPassepartout}
             onChange={() =>
-              setWithPassepartout(withPassepartout ? false : true)
+              setWithPassepartout(() => (withPassepartout ? false : true))
             }
           />
         </Box>

--- a/components/sidebar/FrameSectionDetails.tsx
+++ b/components/sidebar/FrameSectionDetails.tsx
@@ -4,13 +4,14 @@ import { Fragment } from 'react';
 import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
 import { frameDimensions, frames } from '../../data/frameData';
+import { sidebarSections } from '../../lib/valSchemas';
 import SidebarSubtitle from '../shared/SidebarSubtitle';
 import { theme } from '../theme';
 
 const FrameSectionDetails = () => {
   const { frameSet, setFrameSet, setWithPassepartout, withPassepartout } =
     useCanvas();
-  const { allFrames } = useSidebar();
+  const { allFrames, setExpandedAccordion } = useSidebar();
 
   /** Renders correct frame JSX */
   const getFrameJSX = (id: string) => {
@@ -150,12 +151,13 @@ const FrameSectionDetails = () => {
                   size="small"
                   checked={frameSet.size === dimension.size}
                   sx={{ p: 0 }}
-                  onClick={() =>
+                  onClick={() => {
                     setFrameSet((prevState) => ({
                       ...prevState,
                       size: dimension.size,
-                    }))
-                  }
+                    }));
+                    setExpandedAccordion(sidebarSections[2]);
+                  }}
                 />
               </FormControl>
             ))}

--- a/components/sidebar/MobileSidebar.tsx
+++ b/components/sidebar/MobileSidebar.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from '@mui/material';
 import { useSidebar } from '../../context/SidebarContext';
-import { sidebarSections } from '../types';
+import { sidebarSections } from '../../lib/valSchemas';
 
 const MobileSidebar = () => {
   const { openMobileSection, setOpenMobileSection } = useSidebar();

--- a/components/sidebar/PosterSection.tsx
+++ b/components/sidebar/PosterSection.tsx
@@ -1,9 +1,9 @@
 import { useMediaQuery } from '@mui/material';
 import { useSidebar } from '../../context/SidebarContext';
+import { sidebarSections } from '../../lib/valSchemas';
 import MobileSidebarContainer from '../shared/MobileSidebarContainer';
 import SidebarAccordion from '../shared/SidebarAccordion';
 import { theme } from '../theme';
-import { sidebarSections } from '../types';
 import PosterSectionDetails from './PosterSectionDetails';
 
 const PosterSection = () => {

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -1,16 +1,23 @@
-import { Box, Button } from '@mui/material';
+// @ts-nocheck
+import { Box, Button, Typography } from '@mui/material';
 import { IconCheck, IconRectangle, IconRectangleVertical } from '@tabler/icons';
 import Image from 'next/image';
 import { Key } from 'react';
 import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
+import { frameDimensions } from '../../data/frameData';
 import { posterCategories as pCategories } from '../../lib/valSchemas';
 import SidebarSubtitle from '../shared/SidebarSubtitle';
 import { theme } from '../theme';
 
 const PosterSectionDetails = () => {
-  const { poster, setPoster, posterOrientation, setPosterOrientation } =
-    useCanvas();
+  const {
+    poster,
+    setPoster,
+    posterOrientation,
+    setPosterOrientation,
+    frameSet,
+  } = useCanvas();
   const { allPosters, posterCategories, setPosterCategories } = useSidebar();
 
   /** Handles change of orientation state */
@@ -37,7 +44,16 @@ const PosterSectionDetails = () => {
     const noCategory = Object.values(posterCategories).every(
       (v) => v === false
     );
-    const filteredByCategory = allPosters.filter((item) => {
+    const filteredBySize = allPosters.flatMap((poster) =>
+      poster.sizes
+        .filter(
+          (size) =>
+            Number(size.width) === frameDimensions[frameSet.size].width &&
+            Number(size.height) === frameDimensions[frameSet.size].height
+        )
+        .map(() => poster)
+    );
+    const filteredByCategory = filteredBySize.filter((item) => {
       return Object.keys(posterCategories).some((category) => {
         return (
           posterCategories[category as keyof typeof posterCategories] &&
@@ -48,13 +64,13 @@ const PosterSectionDetails = () => {
 
     if (posterOrientation.length > 0) {
       let list = [];
-      noCategory ? (list = allPosters) : (list = filteredByCategory);
+      noCategory ? (list = filteredBySize) : (list = filteredByCategory);
       return list.filter((poster) => poster.orientation === posterOrientation);
     }
-    return noCategory ? allPosters : filteredByCategory;
+    return noCategory ? filteredBySize : filteredByCategory;
   };
 
-  return (
+  return frameSet.id && frameSet.size ? (
     <>
       <SidebarSubtitle subtitle="Poster Type">
         <Box
@@ -122,8 +138,10 @@ const PosterSectionDetails = () => {
           flexWrap: 'wrap',
           gap: 1.5,
           width: '100%',
+          placeContent: 'start',
           justifyContent: 'center',
           my: 2.5,
+          height: '100%',
           overflowY: 'scroll',
           '&::-webkit-scrollbar': {
             width: '0.4em',
@@ -139,7 +157,7 @@ const PosterSectionDetails = () => {
           },
         }}
       >
-        {filteredPosters()!.map((p, index) => (
+        {filteredPosters().map((p, index) => (
           <Box
             key={index}
             sx={{
@@ -180,6 +198,10 @@ const PosterSectionDetails = () => {
         ))}
       </Box>
     </>
+  ) : (
+    <Typography mt={3} width={180} mx="auto" textAlign="center">
+      The posters will appear here after selecting a frame.
+    </Typography>
   );
 };
 

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -179,7 +179,12 @@ const PosterSectionDetails = () => {
               alt={p.title}
               src={p.image}
               onClick={() => {
-                setPoster({ ...poster, id: p.id!, image: p.image });
+                setPoster({
+                  ...poster,
+                  id: p.id!,
+                  image: p.image,
+                  isPortrait: p.orientation === 'Portrait' ? true : false,
+                });
                 setAnchorSidebar(false);
               }}
             />

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -4,11 +4,11 @@ import Image from 'next/image';
 import { Key } from 'react';
 import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
+import { posterCategories } from '../../lib/valSchemas';
 import posterL from '../../public/tempImages/poster-l.png';
 import posterP from '../../public/tempImages/poster-p.png';
 import SidebarSubtitle from '../shared/SidebarSubtitle';
 import { theme } from '../theme';
-import { posterCategories } from '../types';
 
 const PosterSectionDetails = () => {
   const { poster, setPoster, posterOrientation, setPosterOrientation } =

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -18,7 +18,12 @@ const PosterSectionDetails = () => {
     setPosterOrientation,
     frameSet,
   } = useCanvas();
-  const { allPosters, posterCategories, setPosterCategories } = useSidebar();
+  const {
+    allPosters,
+    posterCategories,
+    setPosterCategories,
+    setAnchorSidebar,
+  } = useSidebar();
 
   /** Handles change of orientation state */
   const handleOrientationChange = (value: string) => {
@@ -173,9 +178,10 @@ const PosterSectionDetails = () => {
               height={p.orientation === 'Portrait' ? 65 : 55}
               alt={p.title}
               src={p.image}
-              onClick={() =>
-                setPoster({ ...poster, id: p.id!, image: p.image })
-              }
+              onClick={() => {
+                setPoster({ ...poster, id: p.id!, image: p.image });
+                setAnchorSidebar(false);
+              }}
             />
             {poster.id === p.id ? (
               <IconCheck

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -4,70 +4,54 @@ import Image from 'next/image';
 import { Key } from 'react';
 import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
-import { posterCategories } from '../../lib/valSchemas';
-import posterL from '../../public/tempImages/poster-l.png';
-import posterP from '../../public/tempImages/poster-p.png';
+import { posterCategories as pCategories } from '../../lib/valSchemas';
 import SidebarSubtitle from '../shared/SidebarSubtitle';
 import { theme } from '../theme';
 
 const PosterSectionDetails = () => {
   const { poster, setPoster, posterOrientation, setPosterOrientation } =
     useCanvas();
-  const { posterCategory, setPosterCategory } = useSidebar();
+  const { allPosters, posterCategories, setPosterCategories } = useSidebar();
 
+  /** Handles change of orientation state */
   const handleOrientationChange = (value: string) => {
     posterOrientation !== value
       ? setPosterOrientation(value)
       : setPosterOrientation('');
   };
 
-  const handleCategoryChange = (value: string) => {
-    posterCategory !== value ? setPosterCategory(value) : setPosterCategory('');
-  };
-
-  // To be deleted after we have inserted frames from data
-  const showMePosters = () => {
-    const arr = [];
-    for (let i = 0; i <= 50; i++) {
-      arr.push(
-        {
-          title: 'P1',
-          image: posterP,
-          orientation: 'Portrait',
-          category: 'Abstract',
-        },
-        {
-          title: 'P2',
-          image: posterL,
-          orientation: 'Landscape',
-          category: 'Movies',
-        }
-      );
-      i++;
+  /** Handles selection of one or multiple poster categories */
+  const setCategory = (category: string) => {
+    let newFilter = { ...posterCategories };
+    for (let key in newFilter) {
+      if (key === category) {
+        newFilter[key as keyof typeof posterCategories] =
+          !posterCategories[key as keyof typeof posterCategories];
+      }
     }
-    return arr;
+    setPosterCategories(newFilter);
   };
 
-  // DO NOT delete the below function
   /** Filters posters by selected orientation and category */
   const filteredPosters = () => {
-    if (posterOrientation !== '' && posterCategory !== '') {
-      return showMePosters().filter(
-        (poster) =>
-          poster.orientation === posterOrientation &&
-          poster.category === posterCategory
-      );
-    } else if (posterCategory !== '') {
-      return showMePosters().filter(
-        (poster) => poster.category === posterCategory
-      );
-    } else if (posterOrientation !== '') {
-      return showMePosters().filter(
-        (poster) => poster.orientation === posterOrientation
-      );
-    } else {
-      return showMePosters();
+    const noCategory = Object.values(posterCategories).every(
+      (v) => v === false
+    );
+    const filteredByCategory = allPosters.filter((item) => {
+      return Object.keys(posterCategories).some((category) => {
+        return (
+          posterCategories[category as keyof typeof posterCategories] &&
+          item.categories.includes(category)
+        );
+      });
+    });
+
+    if (posterOrientation.length > 0) {
+      let list = [];
+      noCategory ? (list = allPosters) : (list = filteredByCategory);
+      return list.filter((poster) => poster.orientation === posterOrientation);
     }
+    return noCategory ? allPosters : filteredByCategory;
   };
 
   return (
@@ -112,19 +96,21 @@ const PosterSectionDetails = () => {
           justifyContent: 'center',
         }}
       >
-        {posterCategories.map((category: string, index: Key) => (
+        {pCategories.map((category: string, index: Key) => (
           <Button
             key={index}
             value={category}
             sx={{
-              bgcolor:
-                posterCategory === category ? theme.palette.primary.main : null,
-              color:
-                posterCategory === category
-                  ? theme.palette.primary.contrastText
-                  : null,
+              bgcolor: posterCategories[
+                category as keyof typeof posterCategories
+              ]
+                ? theme.palette.primary.main
+                : null,
+              color: posterCategories[category as keyof typeof posterCategories]
+                ? theme.palette.primary.contrastText
+                : null,
             }}
-            onClick={() => handleCategoryChange(category)}
+            onClick={() => setCategory(category)}
           >
             {category}
           </Button>
@@ -153,7 +139,7 @@ const PosterSectionDetails = () => {
           },
         }}
       >
-        {filteredPosters().map((p, index) => (
+        {filteredPosters()!.map((p, index) => (
           <Box
             key={index}
             sx={{
@@ -161,20 +147,19 @@ const PosterSectionDetails = () => {
               position: 'relative',
               height: p.orientation === 'Portrait' ? 65 : 55,
               boxShadow:
-                poster.id === index.toString() // TODO: change to ID
-                  ? '0px 2px 5px rgba(0, 0, 0, 0.25)'
-                  : null,
+                poster.id === p.id ? '0px 2px 5px rgba(0, 0, 0, 0.25)' : null,
             }}
           >
             <Image
               width={p.orientation === 'Portrait' ? 55 : 65}
               height={p.orientation === 'Portrait' ? 65 : 55}
-              alt={p.title} // TODO: change to title
+              alt={p.title}
               src={p.image}
-              onClick={() => setPoster({ ...poster, id: index.toString() })}
+              onClick={() =>
+                setPoster({ ...poster, id: p.id!, image: p.image })
+              }
             />
-            {/* TODO: adjust logic - this should not be index but id */}
-            {poster.id === index.toString() ? (
+            {poster.id === p.id ? (
               <IconCheck
                 stroke={1}
                 color={theme.palette.primary.contrastText}

--- a/components/types.ts
+++ b/components/types.ts
@@ -33,6 +33,7 @@ export interface CanvasFrameSet {
 export interface CanvasPoster {
   id: string;
   image: string;
+  isPortrait: boolean | undefined;
 }
 
 export interface Poster {

--- a/components/types.ts
+++ b/components/types.ts
@@ -16,7 +16,7 @@ export const posterCategories: string[] = [
   'Other',
 ];
 
-export interface FrameDimension {
+export interface Dimension {
   width: number;
   height: number;
 }
@@ -44,14 +44,24 @@ export interface CanvasFrameSet {
   size: string;
 }
 
-export interface Poster {
+export interface CanvasPoster {
   id: string;
-  src: string;
+  image: string;
+}
+
+export interface Poster {
+  categories: string[];
+  createdAt?: typeof posterCategories;
+  image: string;
+  id?: string;
+  title: string;
+  orientation: string;
+  size: Dimension[];
 }
 
 export interface CanvasItem {
   frame: CanvasFrameSet;
-  poster: { id: string; src: string };
+  poster: CanvasPoster;
   withPassepartout: boolean;
   position: { x: number; y: number };
 }

--- a/components/types.ts
+++ b/components/types.ts
@@ -1,20 +1,6 @@
 import { User as FirebaseUser } from 'firebase/auth';
 import { Timestamp } from 'firebase/firestore';
-import { backgroundCategories } from '../lib/valSchemas';
-
-export const sidebarSections: string[] = ['Background', 'Frame', 'Poster'];
-
-// can be deleted after we have inserted frames from data
-export const posterCategories: string[] = [
-  'Abstract',
-  'Animals',
-  'Floral',
-  'Minimalistic',
-  'Movies',
-  'Nature',
-  'Paintings',
-  'Other',
-];
+import { backgroundCategories, posterCategories } from '../lib/valSchemas';
 
 export interface Dimension {
   width: number;

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -15,6 +15,7 @@ import {
   CanvasItem,
   CanvasPoster,
 } from '../components/types';
+import { useSidebar } from './SidebarContext';
 
 interface CanvasContextValue {
   background: string;
@@ -51,6 +52,7 @@ export const CanvasContext = createContext<CanvasContextValue>({
 });
 
 const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const { setIsEditingFrame } = useSidebar();
   const [background, setBackground] = useState<string>('');
   const [withPassepartout, setWithPassepartout] = useState<boolean>(true);
   const [poster, setPoster] = useState<CanvasPoster>({ id: '', image: '' });
@@ -96,8 +98,9 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
       setPoster({ id: '', image: '' });
       setFrameSet({ id: '', size: '', title: '' });
       setWithPassepartout(true);
+      setIsEditingFrame(false);
     }
-  }, [item]);
+  }, [item, setIsEditingFrame]);
 
   /** Updates the "item" state for single item */
   const updateItemState = useCallback(() => {

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -82,8 +82,6 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     items: [item],
   });
 
-  console.log(poster);
-
   /** Detects the selection under frame section in sidebar and pushes them into the "frameSets" state */
   const updateFrameSetState = useCallback(
     () => setFrameSets([...frameSets, frameSet]),

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -13,7 +13,7 @@ import {
   Canvas,
   CanvasFrameSet,
   CanvasItem,
-  Poster,
+  CanvasPoster,
 } from '../components/types';
 
 interface CanvasContextValue {
@@ -21,8 +21,8 @@ interface CanvasContextValue {
   setBackground: Dispatch<SetStateAction<string>>;
   withPassepartout: boolean;
   setWithPassepartout: Dispatch<SetStateAction<boolean>>;
-  poster: Poster;
-  setPoster: Dispatch<SetStateAction<Poster>>;
+  poster: CanvasPoster;
+  setPoster: Dispatch<SetStateAction<CanvasPoster>>;
   posterOrientation: string;
   setPosterOrientation: Dispatch<SetStateAction<string>>;
   frameSet: CanvasFrameSet;
@@ -38,7 +38,7 @@ export const CanvasContext = createContext<CanvasContextValue>({
   setBackground: () => '',
   withPassepartout: true,
   setWithPassepartout: () => true,
-  poster: { id: '', src: '' },
+  poster: { id: '', image: '' },
   setPoster: () => '',
   posterOrientation: '',
   setPosterOrientation: () => '',
@@ -54,9 +54,10 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [background, setBackground] = useState<string>('');
   const [withPassepartout, setWithPassepartout] = useState<boolean>(true);
   // TODO: the default should be empty but putting something for now for testing
-  const [poster, setPoster] = useState<Poster>({
+  const [poster, setPoster] = useState<CanvasPoster>({
     id: 'NzqeB2wLemjDEO9Sqrjq',
-    src: 'https://firebasestorage.googleapis.com/v0/b/blueprint-298a2.appspot.com/o/posters%2Fmilky%20way%20with%20mountains.jpeg?alt=media&token=ead8bbfe-f1e5-423d-89ee-aab6847ebac8',
+    image:
+      'https://firebasestorage.googleapis.com/v0/b/blueprint-298a2.appspot.com/o/posters%2Fmilky%20way%20with%20mountains.jpeg?alt=media&token=ead8bbfe-f1e5-423d-89ee-aab6847ebac8',
   });
   const [posterOrientation, setPosterOrientation] = useState<string>('');
   const [frameSet, setFrameSet] = useState<CanvasFrameSet>({
@@ -67,7 +68,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [frameSets, setFrameSets] = useState<CanvasFrameSet[]>([]);
   const [item, setItem] = useState<CanvasItem>({
     frame: frameSet,
-    poster: { id: '', src: '' },
+    poster: { id: '', image: '' },
     withPassepartout: true,
     position: { x: 0, y: 0 },
   });
@@ -105,7 +106,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
       setItems((prevState) => [...prevState, item]);
       setItem({
         frame: { id: '', title: '', size: '' },
-        poster: { id: '', src: '' },
+        poster: { id: '', image: '' },
         withPassepartout: true,
         position: { x: 0, y: 0 },
       });

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -39,7 +39,7 @@ export const CanvasContext = createContext<CanvasContextValue>({
   setBackground: () => '',
   withPassepartout: true,
   setWithPassepartout: () => true,
-  poster: { id: '', image: '' },
+  poster: { id: '', image: '', isPortrait: undefined },
   setPoster: () => '',
   posterOrientation: '',
   setPosterOrientation: () => '',
@@ -55,7 +55,11 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const { setIsEditingFrame } = useSidebar();
   const [background, setBackground] = useState<string>('');
   const [withPassepartout, setWithPassepartout] = useState<boolean>(true);
-  const [poster, setPoster] = useState<CanvasPoster>({ id: '', image: '' });
+  const [poster, setPoster] = useState<CanvasPoster>({
+    id: '',
+    image: '',
+    isPortrait: undefined,
+  });
   const [posterOrientation, setPosterOrientation] = useState<string>('');
   const [frameSet, setFrameSet] = useState<CanvasFrameSet>({
     id: '',
@@ -65,7 +69,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [frameSets, setFrameSets] = useState<CanvasFrameSet[]>([]);
   const [item, setItem] = useState<CanvasItem>({
     frame: frameSet,
-    poster: { id: '', image: '' },
+    poster: { id: '', image: '', isPortrait: undefined },
     withPassepartout: withPassepartout,
     position: { x: 0, y: 0 },
   });
@@ -77,6 +81,8 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     user: undefined,
     items: [item],
   });
+
+  console.log(poster);
 
   /** Detects the selection under frame section in sidebar and pushes them into the "frameSets" state */
   const updateFrameSetState = useCallback(
@@ -91,11 +97,11 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
       /** reset all states below as the item has been pushed to the items array state */
       setItem({
         frame: { id: '', title: '', size: '' },
-        poster: { id: '', image: '' },
+        poster: { id: '', image: '', isPortrait: undefined },
         withPassepartout: true,
         position: { x: 0, y: 0 },
       });
-      setPoster({ id: '', image: '' });
+      setPoster({ id: '', image: '', isPortrait: undefined });
       setFrameSet({ id: '', size: '', title: '' });
       setWithPassepartout(true);
       setIsEditingFrame(false);

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -11,6 +11,8 @@ import { Background, Frame, Poster } from '../components/types';
 import { sidebarSections } from '../lib/valSchemas';
 
 interface SidebarContextValue {
+  anchorSidebar: boolean;
+  setAnchorSidebar: Dispatch<SetStateAction<boolean>>;
   expandedAccordion: string | false;
   setExpandedAccordion: Dispatch<SetStateAction<string | false>>;
   openMobileSection: string;
@@ -66,6 +68,8 @@ interface SidebarContextValue {
 }
 
 export const SidebarContext = createContext<SidebarContextValue>({
+  anchorSidebar: true,
+  setAnchorSidebar: () => true,
   expandedAccordion: '',
   setExpandedAccordion: () => '',
   openMobileSection: '',
@@ -101,6 +105,7 @@ export const SidebarContext = createContext<SidebarContextValue>({
 });
 
 const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [anchorSidebar, setAnchorSidebar] = useState<boolean>(true);
   const [expandedAccordion, setExpandedAccordion] = useState<string | false>(
     sidebarSections[0]
   );
@@ -135,6 +140,8 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
     <SidebarContext.Provider
       value={{
+        anchorSidebar,
+        setAnchorSidebar,
         expandedAccordion,
         setExpandedAccordion,
         openMobileSection,

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -35,8 +35,28 @@ interface SidebarContextValue {
       Other: boolean;
     }>
   >;
-  posterCategory: string;
-  setPosterCategory: Dispatch<SetStateAction<string>>;
+  posterCategories: {
+    Abstract: boolean;
+    Animals: boolean;
+    Floral: boolean;
+    Minimalistic: boolean;
+    Movies: boolean;
+    Nature: boolean;
+    Painting: boolean;
+    Other: boolean;
+  };
+  setPosterCategories: Dispatch<
+    SetStateAction<{
+      Abstract: boolean;
+      Animals: boolean;
+      Floral: boolean;
+      Minimalistic: boolean;
+      Movies: boolean;
+      Nature: boolean;
+      Painting: boolean;
+      Other: boolean;
+    }>
+  >;
   allFrames: Frame[];
   setAllFrames: Dispatch<SetStateAction<Frame[]>>;
   allBackgrounds: Background[];
@@ -61,8 +81,17 @@ export const SidebarContext = createContext<SidebarContextValue>({
     Other: false,
   },
   setBackgroundCategories: () => {},
-  posterCategory: '',
-  setPosterCategory: () => '',
+  posterCategories: {
+    Abstract: false,
+    Animals: false,
+    Floral: false,
+    Minimalistic: false,
+    Movies: false,
+    Nature: false,
+    Painting: false,
+    Other: false,
+  },
+  setPosterCategories: () => {},
   allFrames: [],
   setAllFrames: () => [],
   allBackgrounds: [],
@@ -86,7 +115,16 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
     Office: false,
     Other: false,
   });
-  const [posterCategory, setPosterCategory] = useState<string>('');
+  const [posterCategories, setPosterCategories] = useState({
+    Abstract: false,
+    Animals: false,
+    Floral: false,
+    Minimalistic: false,
+    Movies: false,
+    Nature: false,
+    Painting: false,
+    Other: false,
+  });
   const [allFrames, setAllFrames] = useState<Frame[]>([]);
   const [allBackgrounds, setAllBackgrounds] = useState<Background[]>([]);
   const [allPosters, setAllPosters] = useState<Poster[]>([]);
@@ -105,8 +143,8 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
         setIsEditingFrame,
         backgroundCategories,
         setBackgroundCategories,
-        posterCategory,
-        setPosterCategory,
+        posterCategories,
+        setPosterCategories,
         allFrames,
         setAllFrames,
         allBackgrounds,

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -7,12 +7,8 @@ import {
   useContext,
   useState,
 } from 'react';
-import {
-  Background,
-  Frame,
-  Poster,
-  sidebarSections,
-} from '../components/types';
+import { Background, Frame, Poster } from '../components/types';
+import { sidebarSections } from '../lib/valSchemas';
 
 interface SidebarContextValue {
   expandedAccordion: string | false;

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -7,7 +7,12 @@ import {
   useContext,
   useState,
 } from 'react';
-import { Background, Frame, sidebarSections } from '../components/types';
+import {
+  Background,
+  Frame,
+  Poster,
+  sidebarSections,
+} from '../components/types';
 
 interface SidebarContextValue {
   expandedAccordion: string | false;
@@ -40,6 +45,8 @@ interface SidebarContextValue {
   setAllFrames: Dispatch<SetStateAction<Frame[]>>;
   allBackgrounds: Background[];
   setAllBackgrounds: Dispatch<SetStateAction<Background[]>>;
+  allPosters: Poster[];
+  setAllPosters: Dispatch<SetStateAction<Poster[]>>;
 }
 
 export const SidebarContext = createContext<SidebarContextValue>({
@@ -64,6 +71,8 @@ export const SidebarContext = createContext<SidebarContextValue>({
   setAllFrames: () => [],
   allBackgrounds: [],
   setAllBackgrounds: () => [],
+  allPosters: [],
+  setAllPosters: () => [],
 });
 
 const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -84,6 +93,7 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [posterCategory, setPosterCategory] = useState<string>('');
   const [allFrames, setAllFrames] = useState<Frame[]>([]);
   const [allBackgrounds, setAllBackgrounds] = useState<Background[]>([]);
+  const [allPosters, setAllPosters] = useState<Poster[]>([]);
 
   // TODO: setIsEditingFrame must be set to true when a user clicks a frame in the canvas
   const [isEditingFrame, setIsEditingFrame] = useState<boolean>(false);
@@ -105,6 +115,8 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
         setAllFrames,
         allBackgrounds,
         setAllBackgrounds,
+        allPosters,
+        setAllPosters,
       }}
     >
       {children}

--- a/lib/valSchemas.ts
+++ b/lib/valSchemas.ts
@@ -11,6 +11,8 @@ const schemaPoster = yup.object({
   sizes: yup.array().min(1, 'At least one size must be selected').required(),
 });
 
+export const sidebarSections: string[] = ['Background', 'Frame', 'Poster'];
+
 export const posterCategories = [
   'Abstract',
   'Animals',

--- a/pages/example/index.tsx
+++ b/pages/example/index.tsx
@@ -23,15 +23,6 @@ const inter = Inter({ subsets: ['latin'] });
 
 export default function Home(props: any) {
   const postersCollectionRef = collection(db, 'posters');
-
-  // const getPosters = useCallback(async () => {
-  //   const posterData = await getDocs(postersCollectionRef);
-  //   console.log(
-  //     posterData.docs.map((doc) => ({ ...(doc.data() as any), id: doc.id }))
-  //   );
-  // }, [postersCollectionRef]);
-  // // getPosters();
-
   const [file, setFile] = useState<any>('');
   const [percent, setPercent] = useState<number>(0);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,31 +1,35 @@
 import { collection, getDocs } from '@firebase/firestore';
-import { Inter } from '@next/font/google';
 import { InferGetStaticPropsType } from 'next';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { useEffect } from 'react';
-import { Background } from '../components/types';
+import { Background, Frame, Poster } from '../components/types';
 import { useSidebar } from '../context/SidebarContext';
 import { db } from '../firebase/firebaseConfig';
 
 const Test = dynamic(() => import('../components/canvas/Test'), { ssr: false }); // do not adjust this - M1 mac needs this to run canvas
-const inter = Inter({ subsets: ['latin'] });
 
 export const getStaticProps = async () => {
   const framesCollectionRef = collection(db, 'frames');
   const frameData = await getDocs(framesCollectionRef);
-
   const backgroundsCollectionRef = collection(db, 'backgrounds');
   const backgroundData = await getDocs(backgroundsCollectionRef);
+  const postersCollectionRef = collection(db, 'posters');
+  const posterData = await getDocs(postersCollectionRef);
 
   return {
     props: {
       frames: frameData.docs.map((doc) => ({
-        ...(doc.data() as any),
+        ...(doc.data() as Frame),
         id: doc.id,
       })),
       backgrounds: backgroundData.docs.map((doc) => ({
         ...(doc.data() as Background),
+        id: doc.id,
+        createdAt: doc.data().createdAt.toDate().toDateString(),
+      })),
+      posters: posterData.docs.map((doc) => ({
+        ...(doc.data() as Poster),
         id: doc.id,
         createdAt: doc.data().createdAt.toDate().toDateString(),
       })),
@@ -36,14 +40,15 @@ export const getStaticProps = async () => {
 export default function Home({
   frames,
   backgrounds,
+  posters,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const { setAllFrames, setAllBackgrounds } = useSidebar();
-  useEffect(() => {
-    setAllFrames(frames);
-  }, [frames, setAllFrames]);
-  useEffect(() => {
-    setAllBackgrounds(backgrounds);
-  }, [backgrounds, setAllBackgrounds]);
+  const { setAllFrames, setAllBackgrounds, setAllPosters } = useSidebar();
+  useEffect(
+    () => setAllBackgrounds(backgrounds),
+    [backgrounds, setAllBackgrounds]
+  );
+  useEffect(() => setAllFrames(frames), [frames, setAllFrames]);
+  useEffect(() => setAllPosters(posters), [posters, setAllPosters]);
 
   return (
     <>


### PR DESCRIPTION
## Describe your changes
- I forgot to split the issues in 3 branches, so this PR includes 3 issues, sorry 😿... 
- Reorganised types for posters, removed those that are no longer needed
- Fetched poster data from firebase db
- Inserted poster data to sidebar, and adjusted filter function so multiple categories can be chosen 
- Fixed the states in canvas context so the poster is displayed in the frame selected 
- Added and applied a filter to filter poster by size, so only the posters that fit the size of the selected frame are displayed
- Open poster accordion after choosing a frame size, and close sidebar after choosing a poster 
- Show "Add frame" button after successfully adding a frame. Skip the background accordion and open the frame if there is already a background in the canvas
- Added poster orientation to the "poster" state, adjusted the width and height and some pos of the CanvasFrame

## Issue ticket number and link
#52 , #46 ,  #53 