### PR TITLE
#57 remove a frame set

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -69,6 +69,7 @@ const Header = () => {
             alt={currentUser.displayName || currentUser.email}
             src={currentUser.photoURL}
             sx={{
+              fontSize: 11,
               width: 25,
               height: 25,
               cursor: 'pointer',

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import BgSection from './sidebar/BgSection';
 import FrameSection from './sidebar/FrameSection';
 import MobileSidebar from './sidebar/MobileSidebar';
 import PosterSection from './sidebar/PosterSection';
+import RemoveFrameButton from './sidebar/RemoveFrameButton';
 import { theme } from './theme';
 
 const Sidebar = () => {
@@ -64,12 +65,13 @@ const Sidebar = () => {
               flexDirection: 'column',
             }}
           >
-            {isEditingFrame ? (
+            {isEditingFrame.isEditing ? (
               <>
                 {mobile ? <MobileSidebar /> : null}
                 <BgSection />
                 <FrameSection />
                 <PosterSection />
+                {isEditingFrame.item ? <RemoveFrameButton /> : null}
               </>
             ) : (
               <AddFrameButton />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,11 +10,14 @@ import RemoveFrameButton from './sidebar/RemoveFrameButton';
 import { theme } from './theme';
 
 const Sidebar = () => {
-  const { anchorSidebar, setAnchorSidebar } = useSidebar();
-
-  const toggleClose = () => setAnchorSidebar(false);
+  const { anchorSidebar, setAnchorSidebar, setIsEditingFrame } = useSidebar();
   const { isEditingFrame } = useSidebar();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const toggleClose = () => {
+    setAnchorSidebar(false);
+    if (isEditingFrame.item) setIsEditingFrame({ isEditing: false });
+  };
 
   return (
     <>

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -27,7 +27,7 @@ interface Props {
 // saved in the db, as in that case the canvas wont be empty after reloading... or?
 
 const CanvasFrame = (props: Props) => {
-  const { allFrames } = useSidebar();
+  const { allFrames, handleSelectItem } = useSidebar();
   const dimension =
     frameDimensions[props.item.frame.size as keyof typeof frameDimensions];
   const match = allFrames.filter((frame) => frame.id === props.item.frame.id);
@@ -143,6 +143,13 @@ const CanvasFrame = (props: Props) => {
       draggable
       onDragEnd={handleDragEnd}
       ref={groupRef}
+      onClick={() => handleSelectItem(props.item)}
+      onMouseEnter={(e) =>
+        (e.target.getStage()!.container().style.cursor = 'pointer')
+      }
+      onMouseLeave={(e) =>
+        (e.target.getStage()!.container().style.cursor = 'default')
+      }
     >
       <>
         {match[0].category.includes('Wooden') ? (

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -1,5 +1,5 @@
 import Konva from 'konva';
-import { Key, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Group, Image, Rect, Text } from 'react-konva';
 import useImage from 'use-image';
 import { useSidebar } from '../../context/SidebarContext';
@@ -9,7 +9,7 @@ import { CanvasItem } from '../types';
 
 interface Props {
   item: CanvasItem;
-  index: Key;
+  index: number;
   imageScale: {
     scaleX: number;
     scaleY: number;

--- a/components/shared/SidebarAccordion.tsx
+++ b/components/shared/SidebarAccordion.tsx
@@ -16,7 +16,8 @@ interface Props {
 }
 
 const SidebarAccordion = (props: Props) => {
-  const { expandedAccordion, setExpandedAccordion } = useSidebar();
+  const { expandedAccordion, setExpandedAccordion, isEditingFrame } =
+    useSidebar();
 
   // TODO: logic to be fixed for editing from existing canvas, now it is only for "creating new"
   const handleCollapseAccordion = () => {
@@ -59,9 +60,12 @@ const SidebarAccordion = (props: Props) => {
       <AccordionDetails
         sx={{
           maxWidth: 280,
-          minHeight: 'calc(100vh - 200px)',
-          maxHeight: 'calc(100vh - 200px)',
-          height: 'calc(100vh - 200px)',
+          maxHeight: isEditingFrame.item
+            ? 'calc(100vh - 237px)'
+            : 'calc(100vh - 200px)',
+          height: isEditingFrame.item
+            ? 'calc(100vh - 237px)'
+            : 'calc(100vh - 200px)',
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/components/sidebar/FrameSectionDetails.tsx
+++ b/components/sidebar/FrameSectionDetails.tsx
@@ -38,8 +38,10 @@ const FrameSectionDetails = () => {
 
     for (let i = 0; i < matches.length; i++) {
       if (dimensionArr.indexOf(matches[i]) !== -1)
-        // @ts-ignore
-        arr.push({ ...frameDimensions[matches[i]], size: matches[i] });
+        arr.push({
+          ...frameDimensions[matches[i] as keyof typeof frameDimensions],
+          size: matches[i],
+        });
     }
     return arr.sort((a, b) => a.width - b.width);
   };

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Typography } from '@mui/material';
 import { IconCheck, IconRectangle, IconRectangleVertical } from '@tabler/icons';
 import Image from 'next/image';
-import { Key } from 'react';
 import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
 import { frameDimensions } from '../../data/frameData';
@@ -121,7 +120,7 @@ const PosterSectionDetails = () => {
           justifyContent: 'center',
         }}
       >
-        {pCategories.map((category: string, index: Key) => (
+        {pCategories.map((category: string, index: number) => (
           <Button
             key={index}
             value={category}

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Box, Button, Typography } from '@mui/material';
 import { IconCheck, IconRectangle, IconRectangleVertical } from '@tabler/icons';
 import Image from 'next/image';
@@ -9,6 +8,7 @@ import { frameDimensions } from '../../data/frameData';
 import { posterCategories as pCategories } from '../../lib/valSchemas';
 import SidebarSubtitle from '../shared/SidebarSubtitle';
 import { theme } from '../theme';
+import { Dimension } from '../types';
 
 const PosterSectionDetails = () => {
   const {
@@ -52,9 +52,13 @@ const PosterSectionDetails = () => {
     const filteredBySize = allPosters.flatMap((poster) =>
       poster.sizes
         .filter(
-          (size) =>
-            Number(size.width) === frameDimensions[frameSet.size].width &&
-            Number(size.height) === frameDimensions[frameSet.size].height
+          (size: Dimension) =>
+            Number(size.width) ===
+              frameDimensions[frameSet.size as keyof typeof frameDimensions]
+                .width &&
+            Number(size.height) ===
+              frameDimensions[frameSet.size as keyof typeof frameDimensions]
+                .height
         )
         .map(() => poster)
     );

--- a/components/sidebar/RemoveFrameButton.tsx
+++ b/components/sidebar/RemoveFrameButton.tsx
@@ -1,24 +1,19 @@
 import { Box, Typography } from '@mui/material';
-import { IconPlus } from '@tabler/icons';
+import { IconTrash } from '@tabler/icons';
 import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
-import { sidebarSections } from '../../lib/valSchemas';
 import { theme } from '../theme';
 
-const AddFrameButton = () => {
+const RemoveFrameButton = () => {
   const { setIsEditingFrame, setExpandedAccordion } = useSidebar();
   const { background } = useCanvas();
 
   const handleClick = () => {
-    if (background) {
-      setIsEditingFrame({ isEditing: true });
-      setExpandedAccordion(sidebarSections[1]);
-    }
-    setIsEditingFrame({ isEditing: true });
+    console.log('delete');
   };
   return (
     <Box
-      bgcolor="#3A3335"
+      bgcolor="#E23A22"
       color={theme.palette.primary.contrastText}
       sx={{
         display: 'flex',
@@ -27,16 +22,16 @@ const AddFrameButton = () => {
         gap: 0.5,
         cursor: 'pointer',
         '&:hover': {
-          bgcolor: '#524C4E',
+          bgcolor: '#D13838',
         },
       }}
       height={40}
       onClick={handleClick}
     >
-      <IconPlus size={16} stroke={2} />
-      <Typography variant="body1">Add Frame</Typography>
+      <IconTrash size={16} stroke={2} />
+      <Typography variant="body1">Delete Frame</Typography>
     </Box>
   );
 };
 
-export default AddFrameButton;
+export default RemoveFrameButton;

--- a/components/sidebar/RemoveFrameButton.tsx
+++ b/components/sidebar/RemoveFrameButton.tsx
@@ -1,16 +1,11 @@
 import { Box, Typography } from '@mui/material';
 import { IconTrash } from '@tabler/icons';
 import { useCanvas } from '../../context/CanvasContext';
-import { useSidebar } from '../../context/SidebarContext';
 import { theme } from '../theme';
 
 const RemoveFrameButton = () => {
-  const { setIsEditingFrame, setExpandedAccordion } = useSidebar();
-  const { background } = useCanvas();
+  const { deleteFrame } = useCanvas();
 
-  const handleClick = () => {
-    console.log('delete');
-  };
   return (
     <Box
       bgcolor="#E23A22"
@@ -26,7 +21,7 @@ const RemoveFrameButton = () => {
         },
       }}
       height={40}
-      onClick={handleClick}
+      onClick={deleteFrame}
     >
       <IconTrash size={16} stroke={2} />
       <Typography variant="body1">Delete Frame</Typography>

--- a/components/types.ts
+++ b/components/types.ts
@@ -43,7 +43,7 @@ export interface Poster {
   id?: string;
   title: string;
   orientation: string;
-  size: Dimension[];
+  sizes: Dimension[];
 }
 
 export interface CanvasItem {

--- a/components/types.ts
+++ b/components/types.ts
@@ -62,3 +62,8 @@ export interface Canvas {
   background?: string; // TODO: put the correct type. Wille is working on this so i dont bother the type here
   items: CanvasItem[];
 }
+
+export interface EditingFrame {
+  isEditing: boolean;
+  item?: CanvasItem;
+}

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -32,6 +32,7 @@ interface CanvasContextValue {
   setFrameSets: Dispatch<SetStateAction<CanvasFrameSet[]>>;
   canvas: Canvas;
   setCanvas: Dispatch<SetStateAction<Canvas>>;
+  deleteFrame: () => void;
 }
 
 export const CanvasContext = createContext<CanvasContextValue>({
@@ -49,10 +50,11 @@ export const CanvasContext = createContext<CanvasContextValue>({
   setFrameSets: () => [],
   canvas: { user: undefined, items: [] },
   setCanvas: () => {},
+  deleteFrame: () => {},
 });
 
 const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
-  const { setIsEditingFrame } = useSidebar();
+  const { setIsEditingFrame, isEditingFrame, setAnchorSidebar } = useSidebar();
   const [background, setBackground] = useState<string>('');
   const [withPassepartout, setWithPassepartout] = useState<boolean>(true);
   const [poster, setPoster] = useState<CanvasPoster>({
@@ -119,6 +121,14 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     }
   }, [frameSet, poster, updateFrameSetState, withPassepartout]);
 
+  /** Handles click for deleting a frame in the canvas */
+  const deleteFrame = () => {
+    const newList = items.filter((i) => i !== isEditingFrame.item);
+    setItems(newList);
+    if (newList.length > 0) setAnchorSidebar(false);
+    setIsEditingFrame({ isEditing: false });
+  };
+
   /** Detects the states needed for Canvas and pushes them into the "canvas" state */
   /** This function shapes the canvas object for uploading to db - canvas collection */
   const updateCanvasState = useCallback(() => {
@@ -126,7 +136,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     // Now there is only backgournd and items, but missing all other things under type "Canvas"
     if (background)
       setCanvas((prevState) => ({ ...prevState, background: background }));
-    if (items.length > 0)
+    if (items.length >= 0)
       setCanvas((prevState) => ({ ...prevState, items: items }));
   }, [background, items]);
 
@@ -151,6 +161,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
         setFrameSets,
         canvas,
         setCanvas,
+        deleteFrame,
       }}
     >
       {children}

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -102,7 +102,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
       setPoster({ id: '', image: '', isPortrait: undefined });
       setFrameSet({ id: '', size: '', title: '' });
       setWithPassepartout(true);
-      setIsEditingFrame(false);
+      setIsEditingFrame({ isEditing: false });
     }
   }, [item, setIsEditingFrame]);
 

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -7,7 +7,13 @@ import {
   useContext,
   useState,
 } from 'react';
-import { Background, Frame, Poster } from '../components/types';
+import {
+  Background,
+  CanvasItem,
+  EditingFrame,
+  Frame,
+  Poster,
+} from '../components/types';
 import { sidebarSections } from '../lib/valSchemas';
 
 interface SidebarContextValue {
@@ -17,8 +23,8 @@ interface SidebarContextValue {
   setExpandedAccordion: Dispatch<SetStateAction<string | false>>;
   openMobileSection: string;
   setOpenMobileSection: Dispatch<SetStateAction<string>>;
-  isEditingFrame: boolean;
-  setIsEditingFrame: Dispatch<SetStateAction<boolean>>;
+  isEditingFrame: EditingFrame;
+  setIsEditingFrame: Dispatch<SetStateAction<EditingFrame>>;
   backgroundCategories: {
     'Living room': boolean;
     Bedroom: boolean;
@@ -65,6 +71,7 @@ interface SidebarContextValue {
   setAllBackgrounds: Dispatch<SetStateAction<Background[]>>;
   allPosters: Poster[];
   setAllPosters: Dispatch<SetStateAction<Poster[]>>;
+  handleSelectItem: (item: CanvasItem) => void;
 }
 
 export const SidebarContext = createContext<SidebarContextValue>({
@@ -74,8 +81,8 @@ export const SidebarContext = createContext<SidebarContextValue>({
   setExpandedAccordion: () => '',
   openMobileSection: '',
   setOpenMobileSection: () => '',
-  isEditingFrame: false,
-  setIsEditingFrame: () => false,
+  isEditingFrame: { isEditing: false },
+  setIsEditingFrame: () => {},
   backgroundCategories: {
     'Living room': false,
     Bedroom: false,
@@ -102,6 +109,7 @@ export const SidebarContext = createContext<SidebarContextValue>({
   setAllBackgrounds: () => [],
   allPosters: [],
   setAllPosters: () => [],
+  handleSelectItem: () => {},
 });
 
 const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -133,9 +141,17 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [allFrames, setAllFrames] = useState<Frame[]>([]);
   const [allBackgrounds, setAllBackgrounds] = useState<Background[]>([]);
   const [allPosters, setAllPosters] = useState<Poster[]>([]);
+  const [isEditingFrame, setIsEditingFrame] = useState<EditingFrame>({
+    isEditing: false,
+  });
 
-  // TODO: setIsEditingFrame must be set to true when a user clicks a frame in the canvas
-  const [isEditingFrame, setIsEditingFrame] = useState<boolean>(false);
+  const handleSelectItem = (item: CanvasItem) => {
+    setAnchorSidebar(true);
+    setIsEditingFrame({ isEditing: true, item });
+    setExpandedAccordion(sidebarSections[1]);
+  };
+
+  const deleteFrame = () => {};
 
   return (
     <SidebarContext.Provider
@@ -158,6 +174,7 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
         setAllBackgrounds,
         allPosters,
         setAllPosters,
+        handleSelectItem,
       }}
     >
       {children}

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -151,8 +151,6 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
     setExpandedAccordion(sidebarSections[1]);
   };
 
-  const deleteFrame = () => {};
-
   return (
     <SidebarContext.Provider
       value={{


### PR DESCRIPTION
## Describe your changes
- Removed the ts-nocheck and ts-ignore in code 
- Added a DeleteFrameButton component and applied in sidebar. The component is only shown when the isEditingFrame state has isEditing: true && item 
- Added a function to delete the selected frame
- Added some UX improvements (e.g. close sidebar if there are still frames in the canvas, not close it when there is no frame, reset isEditingFrame state when the sidebar is closed, and more...) 
- **NOTE: If the user deletes a frame that does not have the last index, the remaining frames would take the position of the previous frame. I have not done anything in this (nor any position setting except for {x:0, y:0} in my code). This won't be adjusted in this issue as this might actually be preferable in some cases. If we think of an improvement or find it inconvenience to users, there will be a new issue for that.**

## Issue ticket number and link
#57 