### PR TITLE
#58 edit a frame set

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -12,7 +12,7 @@ import { theme } from './theme';
 const Sidebar = () => {
   const { anchorSidebar, setAnchorSidebar, setIsEditingFrame } = useSidebar();
   const { isEditingFrame } = useSidebar();
-  const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const mobile = useMediaQuery(theme.breakpoints.down(800));
 
   const toggleClose = () => {
     setAnchorSidebar(false);
@@ -30,16 +30,30 @@ const Sidebar = () => {
         open={anchorSidebar}
         onClose={toggleClose}
         sx={{
-          mt: '50px',
           display: 'flex',
           flexDirection: 'row',
           '& .MuiDrawer-paper': {
             position: 'absolute',
-            height: 'calc(100vh - 50px)',
-            maxHeight: 'calc(100vh - 50px)',
+            right: 0,
+            top: 50,
             bgcolor: 'transparent',
             boxShadow: 0,
-            overflowY: 'clip',
+            overflowX: 'clip',
+            // the below scrollbar is not supposed to be seen on desktop
+            // it's here only because the user couldnt scroll to the delete button on iphone
+            // other phone models not tested
+            overflowY: isEditingFrame && mobile ? 'scroll' : 'clip',
+            '&::-webkit-scrollbar': {
+              width: 0,
+            },
+            '&::-webkit-scrollbar-track': {
+              boxShadow: 'none',
+              webkitBoxShadow: 'none',
+            },
+            '&::-webkit-scrollbar-thumb': {
+              backgroundColor: 'transparent',
+              outline: 'none',
+            },
           },
         }}
       >
@@ -61,8 +75,8 @@ const Sidebar = () => {
             minWidth={280}
             position="relative"
             sx={{
-              height: 'calc(100vh - 50px)',
-              maxHeight: 'calc(100vh - 50px)',
+              height: mobile ? '100vh' : 'calc(100vh - 50px)',
+              maxHeight: mobile ? '100vh' : 'calc(100vh - 50px)',
               borderLeft: '1px solid #F1F1F1',
               display: 'flex',
               flexDirection: 'column',

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -144,6 +144,7 @@ const CanvasFrame = (props: Props) => {
       onDragEnd={handleDragEnd}
       ref={groupRef}
       onClick={() => handleSelectItem(props.item)}
+      onTap={() => handleSelectItem(props.item)}
       onMouseEnter={(e) =>
         (e.target.getStage()!.container().style.cursor = 'pointer')
       }

--- a/components/shared/MobileSidebarContainer.tsx
+++ b/components/shared/MobileSidebarContainer.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import { ReactNode } from 'react';
+import { useSidebar } from '../../context/SidebarContext';
 import { theme } from '../theme';
 
 interface Props {
@@ -7,6 +8,8 @@ interface Props {
 }
 
 const MobileSidebarContainer = (props: Props) => {
+  const { isEditingFrame } = useSidebar();
+
   return (
     <Box
       bgcolor={theme.palette.primary.contrastText}
@@ -15,9 +18,26 @@ const MobileSidebarContainer = (props: Props) => {
         display: 'flex',
         flexDirection: 'column',
         maxWidth: 280,
-        minHeight: 'calc(100vh - 90px)',
-        maxHeight: 'calc(100vh - 90px)',
+        minHeight: isEditingFrame.item
+          ? 'calc(100vh - 130px)'
+          : 'calc(100vh - 90px)',
+        maxHeight: isEditingFrame.item
+          ? 'calc(100vh - 130px)'
+          : 'calc(100vh - 90px)',
+        overflowX: 'clip',
         overflowY: 'scroll',
+        '&::-webkit-scrollbar': {
+          width: '0.4em',
+        },
+        '&::-webkit-scrollbar-track': {
+          boxShadow: 'inset 0 0 6px rgba(0,0,0,0.00)',
+          webkitBoxShadow: 'inset 0 0 6px rgba(0,0,0,0.00)',
+        },
+        '&::-webkit-scrollbar-thumb': {
+          backgroundColor: 'rgba(0,0,0,.1)',
+          borderRadius: 5,
+          outline: 'none',
+        },
       }}
     >
       {props.children}

--- a/components/sidebar/BgSection.tsx
+++ b/components/sidebar/BgSection.tsx
@@ -7,7 +7,7 @@ import { theme } from '../theme';
 import BgSectionDetails from './BgSectionDetails';
 
 const BgSection = () => {
-  const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const mobile = useMediaQuery(theme.breakpoints.down(800));
   const { openMobileSection } = useSidebar();
 
   return mobile && openMobileSection !== sidebarSections[0] ? null : mobile &&

--- a/components/sidebar/BgSectionDetails.tsx
+++ b/components/sidebar/BgSectionDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from '@mui/material';
+import { Box, Button, useMediaQuery } from '@mui/material';
 import { IconCheck } from '@tabler/icons';
 import Image from 'next/image';
 import { useCanvas } from '../../context/CanvasContext';
@@ -11,6 +11,7 @@ const BgSectionDetails = () => {
   const { background, setBackground } = useCanvas();
   const { setBackgroundCategories, backgroundCategories, allBackgrounds } =
     useSidebar();
+  const mobile = useMediaQuery(theme.breakpoints.down(800));
 
   function setCategory(category: string) {
     let newFilter = { ...backgroundCategories };
@@ -79,7 +80,7 @@ const BgSectionDetails = () => {
           width: '100%',
           justifyContent: 'center',
           my: 2,
-          overflowY: 'scroll',
+          overflowY: !mobile ? 'scroll' : 'null',
           '&::-webkit-scrollbar': {
             width: '0.4em',
           },

--- a/components/sidebar/FrameSection.tsx
+++ b/components/sidebar/FrameSection.tsx
@@ -7,7 +7,7 @@ import { theme } from '../theme';
 import FrameSectionDetails from './FrameSectionDetails';
 
 const FrameSection = () => {
-  const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const mobile = useMediaQuery(theme.breakpoints.down(800));
   const { openMobileSection } = useSidebar();
 
   return mobile && openMobileSection !== sidebarSections[1] ? null : mobile &&

--- a/components/sidebar/FrameSectionDetails.tsx
+++ b/components/sidebar/FrameSectionDetails.tsx
@@ -25,9 +25,14 @@ const FrameSectionDetails = () => {
 
   /** Gets and renders available frame sizes from frame data */
   const getFrameSizes = () => {
+    let frameId: string;
+    !frameSet.id
+      ? (frameId = isEditingFrame.item!.frame.id)
+      : (frameId = frameSet.id);
+
     const arr = [];
     const currentFrame = allFrames
-      .filter((fr) => fr.id === frameSet.id)
+      .filter((fr) => fr.id === frameId)
       .map((fr) => fr);
     const dimensionArr = Object.keys(frameDimensions).flatMap(
       (dimension) => dimension

--- a/components/sidebar/FrameSectionDetails.tsx
+++ b/components/sidebar/FrameSectionDetails.tsx
@@ -11,7 +11,7 @@ import { theme } from '../theme';
 const FrameSectionDetails = () => {
   const { frameSet, setFrameSet, setWithPassepartout, withPassepartout } =
     useCanvas();
-  const { allFrames, setExpandedAccordion } = useSidebar();
+  const { allFrames, setExpandedAccordion, isEditingFrame } = useSidebar();
 
   /** Renders correct frame JSX */
   const getFrameJSX = (id: string) => {
@@ -99,7 +99,24 @@ const FrameSectionDetails = () => {
             }}
           >
             {getFrameJSX(fr.id!)}
-            {frameSet.id === fr.id ? (
+            {isEditingFrame.item &&
+            !frameSet.id &&
+            isEditingFrame.item.frame.id === fr.id ? (
+              <IconCheck
+                stroke={1}
+                color={theme.palette.primary.contrastText}
+                size={15}
+                style={{
+                  background: theme.palette.primary.main,
+                  opacity: 0.7,
+                  borderRadius: 50,
+                  padding: 2,
+                  position: 'absolute',
+                  right: 3,
+                  bottom: 3,
+                }}
+              />
+            ) : frameSet.id === fr.id ? (
               <IconCheck
                 stroke={1}
                 color={theme.palette.primary.contrastText}
@@ -119,7 +136,7 @@ const FrameSectionDetails = () => {
         ))}
       </Box>
 
-      {frameSet.id ? (
+      {frameSet.id || isEditingFrame.item?.frame ? (
         <>
           <SidebarSubtitle subtitle="Size (cm)" />
           <Box
@@ -151,7 +168,11 @@ const FrameSectionDetails = () => {
                 <Checkbox
                   value={dimension.width + 'x' + dimension.height}
                   size="small"
-                  checked={frameSet.size === dimension.size}
+                  checked={
+                    !frameSet.size
+                      ? isEditingFrame.item?.frame.size === dimension.size
+                      : frameSet.size === dimension.size
+                  }
                   sx={{ p: 0 }}
                   onClick={() => {
                     setFrameSet((prevState) => ({

--- a/components/sidebar/PosterSection.tsx
+++ b/components/sidebar/PosterSection.tsx
@@ -7,7 +7,7 @@ import { theme } from '../theme';
 import PosterSectionDetails from './PosterSectionDetails';
 
 const PosterSection = () => {
-  const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const mobile = useMediaQuery(theme.breakpoints.down(800));
   const { openMobileSection } = useSidebar();
 
   return mobile && openMobileSection !== sidebarSections[2] ? null : mobile &&

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -22,6 +22,7 @@ const PosterSectionDetails = () => {
     posterCategories,
     setPosterCategories,
     setAnchorSidebar,
+    isEditingFrame,
   } = useSidebar();
 
   /** Handles change of orientation state */
@@ -45,6 +46,11 @@ const PosterSectionDetails = () => {
 
   /** Filters posters by selected orientation and category */
   const filteredPosters = () => {
+    let sizeKey: string;
+    !frameSet.size
+      ? (sizeKey = isEditingFrame.item!.frame.size)
+      : (sizeKey = frameSet.size);
+
     const noCategory = Object.values(posterCategories).every(
       (v) => v === false
     );
@@ -53,11 +59,9 @@ const PosterSectionDetails = () => {
         .filter(
           (size: Dimension) =>
             Number(size.width) ===
-              frameDimensions[frameSet.size as keyof typeof frameDimensions]
-                .width &&
+              frameDimensions[sizeKey as keyof typeof frameDimensions].width &&
             Number(size.height) ===
-              frameDimensions[frameSet.size as keyof typeof frameDimensions]
-                .height
+              frameDimensions[sizeKey as keyof typeof frameDimensions].height
         )
         .map(() => poster)
     );
@@ -78,7 +82,7 @@ const PosterSectionDetails = () => {
     return noCategory ? filteredBySize : filteredByCategory;
   };
 
-  return frameSet.id && frameSet.size ? (
+  return isEditingFrame.item || (frameSet.id && frameSet.size) ? (
     <>
       <SidebarSubtitle subtitle="Poster Type">
         <Box
@@ -191,7 +195,8 @@ const PosterSectionDetails = () => {
                 setAnchorSidebar(false);
               }}
             />
-            {poster.id === p.id ? (
+            {(isEditingFrame.item && isEditingFrame.item.poster.id === p.id) ||
+            poster.id === p.id ? (
               <IconCheck
                 stroke={1}
                 color={theme.palette.primary.contrastText}

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, Typography, useMediaQuery } from '@mui/material';
 import { IconCheck, IconRectangle, IconRectangleVertical } from '@tabler/icons';
 import Image from 'next/image';
 import { useCanvas } from '../../context/CanvasContext';
@@ -24,6 +24,7 @@ const PosterSectionDetails = () => {
     setAnchorSidebar,
     isEditingFrame,
   } = useSidebar();
+  const mobile = useMediaQuery(theme.breakpoints.down(800));
 
   /** Handles change of orientation state */
   const handleOrientationChange = (value: string) => {
@@ -154,7 +155,7 @@ const PosterSectionDetails = () => {
           justifyContent: 'center',
           my: 2.5,
           height: '100%',
-          overflowY: 'scroll',
+          overflowY: !mobile ? 'scroll' : null,
           '&::-webkit-scrollbar': {
             width: '0.4em',
           },

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -93,7 +93,14 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
   /** Detects if the "item" state is complete and pushes it into the "items" state */
   const updateItemsState = useCallback(() => {
     if (item.frame.id && item.poster.id) {
-      setItems((prevState) => [...prevState, item]);
+      if (!isEditingFrame.item) {
+        setItems((prevState) => [...prevState, item]);
+      } else {
+        const index = items.findIndex(
+          (i) => i.frame === isEditingFrame.item?.frame
+        );
+        items[index] = item;
+      }
       /** reset all states below as the item has been pushed to the items array state */
       setItem({
         frame: { id: '', title: '', size: '' },
@@ -106,7 +113,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
       setWithPassepartout(true);
       setIsEditingFrame({ isEditing: false });
     }
-  }, [item, setIsEditingFrame]);
+  }, [isEditingFrame.item, item, items, setIsEditingFrame]);
 
   /** Updates the "item" state for single item */
   const updateItemState = useCallback(() => {

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -84,41 +84,56 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     items: [item],
   });
 
+  /** reset all states below as the item has been pushed to the items array state */
+  const clearStates = useCallback(() => {
+    setItem({
+      frame: { id: '', title: '', size: '' },
+      poster: { id: '', image: '', isPortrait: undefined },
+      withPassepartout: true,
+      position: { x: 0, y: 0 },
+    });
+    setFrameSet({ id: '', size: '', title: '' });
+    setPoster({ id: '', image: '', isPortrait: undefined });
+  }, []);
+
   /** Detects the selection under frame section in sidebar and pushes them into the "frameSets" state */
-  const updateFrameSetState = useCallback(
-    () => setFrameSets([...frameSets, frameSet]),
-    [frameSet, frameSets]
-  );
+  const updateFrameSetsState = useCallback(() => {
+    setFrameSets([...frameSets, frameSet]);
+  }, [frameSet, frameSets]);
 
   /** Detects if the "item" state is complete and pushes it into the "items" state */
   const updateItemsState = useCallback(() => {
     if (item.frame.id && item.poster.id) {
-      if (!isEditingFrame.item) {
-        setItems((prevState) => [...prevState, item]);
-      } else {
+      if (isEditingFrame.item) {
         const index = items.findIndex(
           (i) => i.frame === isEditingFrame.item?.frame
         );
         items[index] = item;
+      } else {
+        setItems((prevState) => [...prevState, item]);
       }
-      /** reset all states below as the item has been pushed to the items array state */
-      setItem({
-        frame: { id: '', title: '', size: '' },
-        poster: { id: '', image: '', isPortrait: undefined },
-        withPassepartout: true,
-        position: { x: 0, y: 0 },
-      });
-      setPoster({ id: '', image: '', isPortrait: undefined });
-      setFrameSet({ id: '', size: '', title: '' });
-      setWithPassepartout(true);
+      clearStates();
       setIsEditingFrame({ isEditing: false });
     }
-  }, [isEditingFrame.item, item, items, setIsEditingFrame]);
+  }, [clearStates, isEditingFrame.item, item, items, setIsEditingFrame]);
 
   /** Updates the "item" state for single item */
   const updateItemState = useCallback(() => {
-    if (frameSet.id && frameSet.size && poster.id) {
-      updateFrameSetState();
+    if (isEditingFrame.item) {
+      setItem({
+        frame: {
+          id: frameSet.id ? frameSet.id : isEditingFrame.item.frame.id,
+          title: frameSet.title
+            ? frameSet.title
+            : isEditingFrame.item.frame.title,
+          size: frameSet.size ? frameSet.size : isEditingFrame.item.frame.size,
+        },
+        poster: poster ? poster : isEditingFrame.item.poster,
+        withPassepartout: withPassepartout,
+        position: isEditingFrame.item.position, // TODO: position should be from somewhere, but now it's not tracked so i leave it 0,0
+      });
+    } else if (frameSet.id && frameSet.size && poster.id) {
+      updateFrameSetsState();
       setItem({
         frame: frameSet,
         poster: poster,
@@ -126,7 +141,13 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
         position: { x: 0, y: 0 }, // TODO: position should be from somewhere, but now it's not tracked so i leave it 0,0
       });
     }
-  }, [frameSet, poster, updateFrameSetState, withPassepartout]);
+  }, [
+    frameSet,
+    isEditingFrame.item,
+    poster,
+    updateFrameSetsState,
+    withPassepartout,
+  ]);
 
   /** Handles click for deleting a frame in the canvas */
   const deleteFrame = () => {

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -15,6 +15,7 @@ import {
   Poster,
 } from '../components/types';
 import { sidebarSections } from '../lib/valSchemas';
+import { useCanvas } from './CanvasContext';
 
 interface SidebarContextValue {
   anchorSidebar: boolean;
@@ -113,6 +114,7 @@ export const SidebarContext = createContext<SidebarContextValue>({
 });
 
 const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const { setWithPassepartout } = useCanvas();
   const [anchorSidebar, setAnchorSidebar] = useState<boolean>(true);
   const [expandedAccordion, setExpandedAccordion] = useState<string | false>(
     sidebarSections[0]
@@ -146,8 +148,10 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   });
 
   const handleSelectItem = (item: CanvasItem) => {
-    setAnchorSidebar(true);
+    setAnchorSidebar(true); // turn off before sending PR
     setIsEditingFrame({ isEditing: true, item });
+    setWithPassepartout(item.withPassepartout);
+
     setExpandedAccordion(sidebarSections[2]);
   };
 

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -148,7 +148,7 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const handleSelectItem = (item: CanvasItem) => {
     setAnchorSidebar(true);
     setIsEditingFrame({ isEditing: true, item });
-    setExpandedAccordion(sidebarSections[1]);
+    setExpandedAccordion(sidebarSections[2]);
   };
 
   return (


### PR DESCRIPTION
## Describe your changes
- Adjusted updateItemsState function so when the user edits a canvas item, it edits the item selected instead of creating a new one (as what the function was doing previously) 
- Adjusted the code in sidebar so it shows the frame/poster selections from the selected canvas item
- Increased mobile breakpoint to 800px as on my phone (iPhone 14 pro) it shows the desktop sidebar, which it is not supposed to be as that sidebar does not have the optimised UX for mobile users
- Added the "delete frame" button in mobile sidebar. Adjusted styling especially overflowY for mobile so the user can scroll to the delete button
- **The issue is complete but there could be an improvement of UX, a "good-to-have" issue will be created for sprint 5:**
   - For now the user has to get through the whole process of choosing frame and poster to get the frame refreshed in the canvas instead of immediate preview. 

**Since mac doesnt have the same scrollbar as PC, if you spot any scrollbar problem please make a screenshot and create a new issue 😄**

## Issue ticket number and link
#58 and #27 (had to fix #27 in order to get the "delete button" on mobile visible 🍖 ) 

