### PR TITLE
44 11 1 adjust frame size in canvas not sidebar

### DIFF
--- a/components/canvas/Test.tsx
+++ b/components/canvas/Test.tsx
@@ -39,7 +39,6 @@ function Test() {
 
   const [canvasBackground] = useImage(background);
 
-  // let x:  number, y:number, width: number, height: number, scaleX:number, scaleY:number;
   let x = 0,
     y = 0,
     width = 0,
@@ -65,25 +64,6 @@ function Test() {
   }
 
   const [selectedId, selectShape] = useState<number | null>(null);
-  // const shapeRef = useRef<Konva.Rect>(null);
-  // const trRef = useRef<Konva.Transformer>(null);
-  // const [rectangles, setRectangles] = useState(initialRec);
-  // const [selected, setSelected] = useState(false);
-
-  // useEffect(() => {
-  //   if (selected && trRef.current && shapeRef.current) {
-  //     trRef.current.nodes([shapeRef.current]);
-  //     trRef.current.getLayer().batchDraw();
-  //     trRef.current.centeredScaling(true);
-  //     // trRef.current.enabledAnchors([
-  //     //   'top-left',
-  //     //   'top-right',
-  //     //   'bottom-left',
-  //     //   'bottom-right',
-  //     // ]);
-  //     trRef.current.flipEnabled(false);
-  //   }
-  // }, [selected]);
 
   const checkDeselect = (e: Konva.KonvaEventObject<MouseEvent>) => {
     // deselect when clicked on empty area
@@ -127,72 +107,7 @@ function Test() {
             ) : null
           )}
         </Layer>
-        <Layer>
-          {/* <>
-            <Rect
-              draggable
-              ref={shapeRef}
-              x={rectangles.x}
-              y={rectangles.y}
-              width={rectangles.width}
-              height={rectangles.height}
-              fill={rectangles.fill}
-              onClick={() => setSelected(true)}
-              onTap={() => setSelected(true)}
-              onDragEnd={(e) => {
-                setRectangles({
-                  ...rectangles,
-                  x: e.target.x(),
-                  y: e.target.y(),
-                });
-              }}
-              onTransformEnd={(e) => {
-                // transformer is changing scale of the node
-                // and NOT its width or height
-                // but in the store we have only width and height
-                // to match the data better we will reset scale on transform end
-                const node = shapeRef.current;
-                if (node) {
-                  let maxW = 200;
-
-                  let scaleX = node.scaleX();
-                  let scaleY = node.scaleY();
-                  const width = node.width() * scaleX;
-                  const height = node.width() * scaleY;
-                  if (width > maxW) {
-                    scaleX = maxW / node.width();
-                  }
-                  if (height > maxW) {
-                    scaleY = maxW / node.height();
-                  }
-                  // we will reset it back
-                  node.scaleX(1);
-                  node.scaleY(1);
-                  setRectangles({
-                    ...rectangles,
-                    x: node.x(),
-                    y: node.y(),
-                    // set minimal value
-                    width: Math.max(5, node.width() * scaleX),
-                    height: Math.max(5, node.height() * scaleY),
-                  });
-                }
-              }}
-            />
-
-            <Transformer
-              ref={trRef}
-              rotateEnabled={false}
-              boundBoxFunc={(oldBox, newBox) => {
-                // limit resize
-                if (newBox.width < 5 || newBox.height < 5) {
-                  return oldBox;
-                }
-                return newBox;
-              }}
-            /> */}
-          {/* </> */}
-        </Layer>
+        <Layer></Layer>
       </Stage>
     </Container>
   );

--- a/components/canvas/Test.tsx
+++ b/components/canvas/Test.tsx
@@ -1,4 +1,5 @@
 import { Container } from '@mui/material';
+import Konva from 'konva';
 import { useEffect, useRef, useState } from 'react';
 import { Image, Layer, Stage } from 'react-konva';
 import useImage from 'use-image';
@@ -63,9 +64,44 @@ function Test() {
     y = (dimensions.height - height) / 2;
   }
 
+  const [selectedId, selectShape] = useState<number | null>(null);
+  // const shapeRef = useRef<Konva.Rect>(null);
+  // const trRef = useRef<Konva.Transformer>(null);
+  // const [rectangles, setRectangles] = useState(initialRec);
+  // const [selected, setSelected] = useState(false);
+
+  // useEffect(() => {
+  //   if (selected && trRef.current && shapeRef.current) {
+  //     trRef.current.nodes([shapeRef.current]);
+  //     trRef.current.getLayer().batchDraw();
+  //     trRef.current.centeredScaling(true);
+  //     // trRef.current.enabledAnchors([
+  //     //   'top-left',
+  //     //   'top-right',
+  //     //   'bottom-left',
+  //     //   'bottom-right',
+  //     // ]);
+  //     trRef.current.flipEnabled(false);
+  //   }
+  // }, [selected]);
+
+  const checkDeselect = (e: Konva.KonvaEventObject<MouseEvent>) => {
+    // deselect when clicked on empty area
+    const clickedOnEmpty =
+      e.target === e.target.getStage() ||
+      e.target.attrs.alt === 'Canvas background';
+    if (clickedOnEmpty) {
+      selectShape(null);
+    }
+  };
+
   return (
     <Container sx={{ height: '100%' }} ref={stageCanvasRef}>
-      <Stage height={dimensions.height} width={dimensions.width}>
+      <Stage
+        height={dimensions.height}
+        width={dimensions.width}
+        onMouseDown={checkDeselect}
+      >
         <Layer>
           {canvasBackground && (
             <Image
@@ -85,9 +121,77 @@ function Test() {
                 index={index}
                 imageScale={{ scaleX, scaleY }}
                 bg={{ width, height, x, y }}
+                selectShape={selectShape}
+                isSelected={index === selectedId}
               />
             ) : null
           )}
+        </Layer>
+        <Layer>
+          {/* <>
+            <Rect
+              draggable
+              ref={shapeRef}
+              x={rectangles.x}
+              y={rectangles.y}
+              width={rectangles.width}
+              height={rectangles.height}
+              fill={rectangles.fill}
+              onClick={() => setSelected(true)}
+              onTap={() => setSelected(true)}
+              onDragEnd={(e) => {
+                setRectangles({
+                  ...rectangles,
+                  x: e.target.x(),
+                  y: e.target.y(),
+                });
+              }}
+              onTransformEnd={(e) => {
+                // transformer is changing scale of the node
+                // and NOT its width or height
+                // but in the store we have only width and height
+                // to match the data better we will reset scale on transform end
+                const node = shapeRef.current;
+                if (node) {
+                  let maxW = 200;
+
+                  let scaleX = node.scaleX();
+                  let scaleY = node.scaleY();
+                  const width = node.width() * scaleX;
+                  const height = node.width() * scaleY;
+                  if (width > maxW) {
+                    scaleX = maxW / node.width();
+                  }
+                  if (height > maxW) {
+                    scaleY = maxW / node.height();
+                  }
+                  // we will reset it back
+                  node.scaleX(1);
+                  node.scaleY(1);
+                  setRectangles({
+                    ...rectangles,
+                    x: node.x(),
+                    y: node.y(),
+                    // set minimal value
+                    width: Math.max(5, node.width() * scaleX),
+                    height: Math.max(5, node.height() * scaleY),
+                  });
+                }
+              }}
+            />
+
+            <Transformer
+              ref={trRef}
+              rotateEnabled={false}
+              boundBoxFunc={(oldBox, newBox) => {
+                // limit resize
+                if (newBox.width < 5 || newBox.height < 5) {
+                  return oldBox;
+                }
+                return newBox;
+              }}
+            /> */}
+          {/* </> */}
         </Layer>
       </Stage>
     </Container>

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -100,7 +100,7 @@ const CanvasFrame = (props: Props) => {
   const multiplyValue = 20;
 
   let imageAspectRatio,
-    scaleFactor: number | undefined,
+    scaleFactor = 1,
     imageWidth = 1,
     imageHeight = 1;
   if (poster && props.imageScale.scaleX && props.imageScale.scaleY) {
@@ -158,8 +158,8 @@ const CanvasFrame = (props: Props) => {
   const imageRef = useRef<Konva.Image>(null);
   const transformRef = useRef<Konva.Transformer>(null);
   const [size, setSize] = useState<{ width: number; height: number }>({
-    width: 50,
-    height: 70,
+    width: imageWidth,
+    height: imageHeight,
   });
 
   useEffect(() => {
@@ -180,11 +180,26 @@ const CanvasFrame = (props: Props) => {
   const [imagePos, setImagePos] = useState({ x: 50, y: 50 });
 
   const allFrameSizes = [
-    { width: 21, height: 30 },
-    { width: 30, height: 40 },
-    { width: 40, height: 50 },
-    { width: 50, height: 70 },
-    { width: 70, height: 100 },
+    {
+      width: 21 * multiplyValue * scaleFactor,
+      height: 30 * multiplyValue * scaleFactor,
+    },
+    {
+      width: 30 * multiplyValue * scaleFactor,
+      height: 40 * multiplyValue * scaleFactor,
+    },
+    {
+      width: 40 * multiplyValue * scaleFactor,
+      height: 50 * multiplyValue * scaleFactor,
+    },
+    {
+      width: 50 * multiplyValue * scaleFactor,
+      height: 70 * multiplyValue * scaleFactor,
+    },
+    {
+      width: 70 * multiplyValue * scaleFactor,
+      height: 100 * multiplyValue * scaleFactor,
+    },
   ];
 
   const handleTransformEnd = () => {
@@ -385,8 +400,8 @@ const CanvasFrame = (props: Props) => {
       <Image
         image={poster}
         alt="cola"
-        width={50}
-        height={70}
+        width={50 * multiplyValue * scaleFactor}
+        height={70 * multiplyValue * scaleFactor}
         ref={imageRef}
         draggable
         onDragEnd={(e) => {
@@ -409,7 +424,12 @@ const CanvasFrame = (props: Props) => {
               ? curr
               : prev;
           });
-          setSize(closestSize);
+          setSize({
+            width: Math.round(closestSize.width / multiplyValue / scaleFactor),
+            height: Math.round(
+              closestSize.height / multiplyValue / scaleFactor
+            ),
+          });
         }}
         boundBoxFunc={(oldBox, newBox) => {
           // get the current size of the image
@@ -422,21 +442,22 @@ const CanvasFrame = (props: Props) => {
 
           // find the next fixed size based on the distance the user dragged the anchor
           let nextSize = null;
-          if (newBox.width - bbox.width > 20) {
+          if (newBox.width - bbox.width > 20 * multiplyValue * scaleFactor) {
             // find the next larger fixed size
             nextSize = allFrameSizes.find((size) => size.width > bbox.width);
-          } else if (bbox.width - newBox.width > 20) {
+          } else if (
+            bbox.width - newBox.width >
+            20 * multiplyValue * scaleFactor
+          ) {
             // find the next smaller fixed size
             nextSize = allFrameSizes
               .reverse()
               .find((size) => size.width < bbox.width);
-          }
-
-          // return the bounding box with the next fixed size, if found
+          } // return the bounding box with the next fixed size, if found
           if (nextSize) {
             setSize({
-              width: nextSize.width,
-              height: nextSize.height,
+              width: Math.round(nextSize.width / multiplyValue / scaleFactor),
+              height: Math.round(nextSize.height / multiplyValue / scaleFactor),
             });
             return {
               x: bbox.x,
@@ -451,6 +472,7 @@ const CanvasFrame = (props: Props) => {
           return oldBox;
         }}
       />
+
       {size && (
         <Text
           x={imagePos.x + size.width / 2}

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -132,8 +132,14 @@ const CanvasFrame = (props: Props) => {
   });
 
   const [scaledSizes, setScaledSizes] = useState({
-    width: size.width * multiplyValue * scaleFactor,
-    height: size.height * multiplyValue * scaleFactor,
+    width:
+      (props.item.poster.isPortrait ? dimension.width : dimension.height) *
+      multiplyValue *
+      scaleFactor,
+    height:
+      (props.item.poster.isPortrait ? dimension.height : dimension.width) *
+      multiplyValue *
+      scaleFactor,
   });
 
   useEffect(() => {
@@ -372,13 +378,15 @@ const CanvasFrame = (props: Props) => {
               opacity={0.5}
             />
           </Group>
-          <Text
-            text={size.width + 'x' + size.height}
-            x={scaledSizes.width / 2 - 20}
-            y={scaledSizes.height + 10}
-            fontFamily={theme.typography.fontFamily}
-            fontSize={Number(theme.typography.body1.fontSize)}
-          />
+          {props.isSelected && (
+            <Text
+              text={size.width + 'x' + size.height}
+              x={scaledSizes.width / 2 - 20}
+              y={scaledSizes.height + 10}
+              fontFamily={theme.typography.fontFamily}
+              fontSize={Number(theme.typography.body1.fontSize)}
+            />
+          )}
           {props.isSelected && posterSizes.length < 2 && (
             <Text
               text="This poster only has this size"

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -3,6 +3,7 @@ import { isEqual } from 'lodash';
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { Group, Image, Rect, Text, Transformer } from 'react-konva';
 import useImage from 'use-image';
+import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
 import { frameDimensions } from '../../data/frameData';
 import { theme } from '../theme';
@@ -31,6 +32,8 @@ interface Props {
 
 const CanvasFrame = (props: Props) => {
   const { allFrames, handleSelectItem } = useSidebar();
+  // TODO: call setFrameSet to change the frame size whenever the user has resized it.
+  const { setFrameSet } = useCanvas();
   const dimension =
     frameDimensions[props.item.frame.size as keyof typeof frameDimensions];
   const match = allFrames.filter((frame) => frame.id === props.item.frame.id);
@@ -186,6 +189,13 @@ const CanvasFrame = (props: Props) => {
     });
   }, [frameBorder, scaleFactor, dimension, props, size]);
 
+  useEffect(() => {
+    setSize({
+      width: props.item.poster.isPortrait ? dimension.width : dimension.height,
+      height: props.item.poster.isPortrait ? dimension.height : dimension.width,
+    });
+  }, [dimension, props.item.poster.isPortrait]);
+
   const handleDragEnd = (e: Konva.KonvaEventObject<DragEvent>) => {
     setElementPos({
       x: e.target.x(),
@@ -206,7 +216,7 @@ const CanvasFrame = (props: Props) => {
       y: newY,
     };
   };
-  return (
+  return poster ? (
     <>
       <Rect
         fill="transparent"
@@ -489,7 +499,7 @@ const CanvasFrame = (props: Props) => {
         />
       )}
     </>
-  );
+  ) : null;
 };
 
 export default CanvasFrame;

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -1,6 +1,6 @@
 import Konva from 'konva';
-import { Dispatch, SetStateAction, useRef, useState } from 'react';
-import { Group, Image, Rect, Text } from 'react-konva';
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import { Group, Image, Rect, Text, Transformer } from 'react-konva';
 import useImage from 'use-image';
 import { useSidebar } from '../../context/SidebarContext';
 import { frameDimensions } from '../../data/frameData';
@@ -34,7 +34,6 @@ const CanvasFrame = (props: Props) => {
     frameDimensions[props.item.frame.size as keyof typeof frameDimensions];
   const match = allFrames.filter((frame) => frame.id === props.item.frame.id);
 
-  const groupRef = useRef<Konva.Group>(null);
   const [elementPos, setElementPos] = useState({ x: 20, y: 50 });
 
   const [poster] = useImage(props.item.poster.image);
@@ -132,6 +131,23 @@ const CanvasFrame = (props: Props) => {
       y: newY,
     };
   };
+  const groupRef = useRef<Konva.Group>(null);
+  const trRef = useRef<Konva.Transformer>(null);
+
+  useEffect(() => {
+    if (props.isSelected && trRef.current && groupRef.current) {
+      trRef.current.nodes([groupRef.current]);
+      trRef.current.getLayer()!.batchDraw();
+      trRef.current.centeredScaling(true);
+      // trRef.current.enabledAnchors([
+      //   'top-left',
+      //   'top-right',
+      //   'bottom-left',
+      //   'bottom-right',
+      // ]);
+      trRef.current.flipEnabled(false);
+    }
+  }, [props.isSelected]);
 
   return (
     <>
@@ -311,6 +327,20 @@ const CanvasFrame = (props: Props) => {
           />
         </>
       </Group>
+      {props.isSelected && (
+        <Transformer
+          ref={trRef}
+          rotateEnabled={false}
+          resizeEnabled={false}
+          boundBoxFunc={(oldBox, newBox) => {
+            // limit resize
+            if (newBox.width < 5 || newBox.height < 5) {
+              return oldBox;
+            }
+            return newBox;
+          }}
+        />
+      )}
     </>
   );
 };

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -1,5 +1,5 @@
 import Konva from 'konva';
-import { Key, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useRef, useState } from 'react';
 import { Group, Image, Rect, Text } from 'react-konva';
 import useImage from 'use-image';
 import { useSidebar } from '../../context/SidebarContext';
@@ -9,7 +9,7 @@ import { CanvasItem } from '../types';
 
 interface Props {
   item: CanvasItem;
-  index: Key;
+  index: number;
   imageScale: {
     scaleX: number;
     scaleY: number;
@@ -20,6 +20,8 @@ interface Props {
     x?: number;
     y?: number;
   };
+  selectShape: Dispatch<SetStateAction<number | null>>;
+  isSelected: boolean;
 }
 
 // TODO: what is missing here is the frame scaling and previous position
@@ -42,10 +44,6 @@ const CanvasFrame = (props: Props) => {
   const [walnut] = useImage(
     'https://firebasestorage.googleapis.com/v0/b/blueprint-298a2.appspot.com/o/frames%2Fwalnut-surface.jpeg?alt=media&token=e0224afc-7b60-414e-8922-63804d3f7f4c'
   );
-  // const pos = () => {
-  //   if (props.index === 0) return { x: 20, y: 30 };
-  //   return { x: 20 * (props.index + 1), y: 30 };
-  // };
 
   const frameBorder = () => {
     let frameBorder;
@@ -136,176 +134,184 @@ const CanvasFrame = (props: Props) => {
   };
 
   return (
-    <Group
-      x={elementPos.x}
-      y={elementPos.y}
-      dragBoundFunc={handleDrag}
-      draggable
-      onDragEnd={handleDragEnd}
-      ref={groupRef}
-    >
-      <>
-        {match[0].category.includes('Wooden') ? (
+    <>
+      <Group
+        x={elementPos.x}
+        y={elementPos.y}
+        dragBoundFunc={handleDrag}
+        draggable
+        onDragEnd={handleDragEnd}
+        ref={groupRef}
+        onClick={() => props.selectShape(props.index)}
+      >
+        <>
+          {match[0].category.includes('Wooden') ? (
+            <Image
+              image={frameColor() as HTMLImageElement}
+              alt={match[0].title}
+              width={imageWidth}
+              height={imageHeight}
+              shadowBlur={15}
+              shadowColor="#000"
+              shadowOpacity={0.5}
+              shadowOffset={{ x: 0, y: 5 }}
+            />
+          ) : (
+            <Rect
+              width={imageWidth}
+              height={imageHeight}
+              fill={frameColor() as string}
+              shadowBlur={15}
+              shadowColor="#000"
+              shadowOpacity={0.5}
+              shadowOffset={{ x: 0, y: 5 }}
+            />
+          )}
           <Image
-            image={frameColor() as HTMLImageElement}
-            alt={match[0].title}
-            width={imageWidth}
-            height={imageHeight}
-            shadowBlur={15}
-            shadowColor="#000"
-            shadowOpacity={0.5}
-            shadowOffset={{ x: 0, y: 5 }}
-          />
-        ) : (
-          <Rect
-            width={imageWidth}
-            height={imageHeight}
-            fill={frameColor() as string}
-            shadowBlur={15}
-            shadowColor="#000"
-            shadowOpacity={0.5}
-            shadowOffset={{ x: 0, y: 5 }}
-          />
-        )}
-        <Image
-          image={poster}
-          alt="cola"
-          x={frameBorder()}
-          y={frameBorder()}
-          width={imageWidth - frameBorder() * 2}
-          height={imageHeight - frameBorder() * 2}
-        />
-        {props.item.withPassepartout ? (
-          <>
-            {/*  passepartout. Sequence: left, right, top, bottom*/}
-            <Group>
-              <Rect
-                x={frameBorder()}
-                y={frameBorder()}
-                width={passepartout() - frameBorder()}
-                height={imageHeight - frameBorder() * 2}
-                fill="#f8f8f8"
-              />
-              <Rect
-                x={imageWidth - passepartout()}
-                y={frameBorder()}
-                width={passepartout() - frameBorder()}
-                height={imageHeight - frameBorder() * 2}
-                fill="#f8f8f8"
-              />
-              <Rect
-                x={frameBorder()}
-                y={frameBorder()}
-                width={imageWidth - frameBorder() * 2}
-                height={passepartout() * 1.1 - frameBorder()}
-                fill="#f8f8f8"
-              />
-              <Rect
-                x={frameBorder()}
-                y={imageHeight - passepartout() * 1.1}
-                width={imageWidth - frameBorder() * 2}
-                height={passepartout() * 1.1 - frameBorder()}
-                fill="#f8f8f8"
-              />
-            </Group>
-            {/* shadow for passepartout. Sequence: left, right, top, bottom*/}
-            <Group>
-              <Rect
-                x={passepartout()}
-                y={passepartout() * 1.1 + 1}
-                width={1}
-                height={imageHeight - passepartout() * 1.1 * 2 - 1}
-                fill="#eee"
-                shadowBlur={0.25}
-                shadowColor="#000"
-                shadowOpacity={0.6}
-                shadowOffset={{ x: 0, y: 0 }}
-              />
-              <Rect
-                x={imageWidth - passepartout()}
-                y={passepartout() * 1.1 + 1}
-                width={1}
-                height={imageHeight - passepartout() * 1.1 * 2 - 1}
-                fill="#eee"
-                shadowBlur={0.25}
-                shadowColor="#000"
-                shadowOpacity={0.6}
-                shadowOffset={{ x: 0, y: 0 }}
-              />
-              <Rect
-                x={passepartout()}
-                y={passepartout() * 1.1}
-                width={imageWidth - passepartout() * 2 + 1}
-                height={1}
-                fill="#ddd"
-                shadowBlur={0.5}
-                shadowColor="#000"
-                shadowOpacity={0.2}
-                shadowOffset={{ x: 0, y: 0 }}
-              />
-              <Rect
-                x={passepartout()}
-                y={imageHeight - passepartout() * 1.1}
-                width={imageWidth - passepartout() * 2 + 1}
-                height={1}
-                fill="#fff"
-              />
-            </Group>
-          </>
-        ) : null}
-        {/* shadow for frame. Sequence: left, right, top, bottom*/}
-        <Group>
-          <Rect
-            x={frameBorder()}
-            y={frameBorder() + 1}
-            width={1}
-            height={imageHeight - frameBorder() * 2 - 1}
-            fill="#eee"
-            shadowBlur={3}
-            shadowColor="#ddd"
-            shadowOpacity={0.7}
-            shadowOffset={{ x: 2, y: 0 }}
-          />
-          <Rect
-            x={imageWidth - frameBorder()}
-            y={frameBorder() + 1}
-            width={1}
-            height={imageHeight - frameBorder() * 2 - 1}
-            fill="#eee"
-            shadowBlur={3}
-            shadowColor="#ddd"
-            shadowOpacity={0.7}
-            shadowOffset={{ x: -2, y: 0 }}
-          />
-          <Rect
+            image={poster}
+            alt="cola"
             x={frameBorder()}
             y={frameBorder()}
-            width={imageWidth - frameBorder() * 2 + 1}
-            height={1}
-            fill="#ddd"
-            shadowBlur={13}
-            shadowColor="#000"
-            shadowOpacity={1}
-            shadowOffset={{ x: 0, y: 6 }}
+            width={imageWidth - frameBorder() * 2}
+            height={imageHeight - frameBorder() * 2}
           />
-          <Rect
-            x={frameBorder()}
-            y={imageHeight - frameBorder()}
-            width={imageWidth - frameBorder() * 2 + 1}
-            height={1}
-            fill="#fff"
-            opacity={0.5}
+          {props.item.withPassepartout ? (
+            <>
+              {/*  passepartout. Sequence: left, right, top, bottom*/}
+              <Group>
+                <Rect
+                  x={frameBorder()}
+                  y={frameBorder()}
+                  width={passepartout() - frameBorder()}
+                  height={imageHeight - frameBorder() * 2}
+                  fill="#f8f8f8"
+                />
+                <Rect
+                  x={imageWidth - passepartout()}
+                  y={frameBorder()}
+                  width={passepartout() - frameBorder()}
+                  height={imageHeight - frameBorder() * 2}
+                  fill="#f8f8f8"
+                />
+                <Rect
+                  x={frameBorder()}
+                  y={frameBorder()}
+                  width={imageWidth - frameBorder() * 2}
+                  height={passepartout() * 1.1 - frameBorder()}
+                  fill="#f8f8f8"
+                />
+                <Rect
+                  x={frameBorder()}
+                  y={imageHeight - passepartout() * 1.1}
+                  width={imageWidth - frameBorder() * 2}
+                  height={passepartout() * 1.1 - frameBorder()}
+                  fill="#f8f8f8"
+                />
+              </Group>
+              {/* shadow for passepartout. Sequence: left, right, top, bottom*/}
+              <Group>
+                <Rect
+                  x={passepartout()}
+                  y={passepartout() * 1.1 + 1}
+                  width={1}
+                  height={imageHeight - passepartout() * 1.1 * 2 - 1}
+                  fill="#eee"
+                  shadowBlur={0.25}
+                  shadowColor="#000"
+                  shadowOpacity={0.6}
+                  shadowOffset={{ x: 0, y: 0 }}
+                />
+                <Rect
+                  x={imageWidth - passepartout()}
+                  y={passepartout() * 1.1 + 1}
+                  width={1}
+                  height={imageHeight - passepartout() * 1.1 * 2 - 1}
+                  fill="#eee"
+                  shadowBlur={0.25}
+                  shadowColor="#000"
+                  shadowOpacity={0.6}
+                  shadowOffset={{ x: 0, y: 0 }}
+                />
+                <Rect
+                  x={passepartout()}
+                  y={passepartout() * 1.1}
+                  width={imageWidth - passepartout() * 2 + 1}
+                  height={1}
+                  fill="#ddd"
+                  shadowBlur={0.5}
+                  shadowColor="#000"
+                  shadowOpacity={0.2}
+                  shadowOffset={{ x: 0, y: 0 }}
+                />
+                <Rect
+                  x={passepartout()}
+                  y={imageHeight - passepartout() * 1.1}
+                  width={imageWidth - passepartout() * 2 + 1}
+                  height={1}
+                  fill="#fff"
+                />
+              </Group>
+            </>
+          ) : null}
+          {/* shadow for frame. Sequence: left, right, top, bottom*/}
+          <Group>
+            <Rect
+              x={frameBorder()}
+              y={frameBorder() + 1}
+              width={1}
+              height={imageHeight - frameBorder() * 2 - 1}
+              fill="#eee"
+              shadowBlur={3}
+              shadowColor="#ddd"
+              shadowOpacity={0.7}
+              shadowOffset={{ x: 2, y: 0 }}
+            />
+            <Rect
+              x={imageWidth - frameBorder()}
+              y={frameBorder() + 1}
+              width={1}
+              height={imageHeight - frameBorder() * 2 - 1}
+              fill="#eee"
+              shadowBlur={3}
+              shadowColor="#ddd"
+              shadowOpacity={0.7}
+              shadowOffset={{ x: -2, y: 0 }}
+            />
+            <Rect
+              x={frameBorder()}
+              y={frameBorder()}
+              width={imageWidth - frameBorder() * 2 + 1}
+              height={1}
+              fill="#ddd"
+              shadowBlur={13}
+              shadowColor="#000"
+              shadowOpacity={1}
+              shadowOffset={{ x: 0, y: 6 }}
+            />
+            <Rect
+              x={frameBorder()}
+              y={imageHeight - frameBorder()}
+              width={imageWidth - frameBorder() * 2 + 1}
+              height={1}
+              fill="#fff"
+              opacity={0.5}
+            />
+          </Group>
+          <Text
+            text={
+              dimension.width +
+              'x' +
+              dimension.height +
+              `${props.isSelected ? 'selected' : 'not selected'}`
+            }
+            x={imageWidth / 2 - 20}
+            y={imageHeight + 10}
+            fontFamily={theme.typography.fontFamily}
+            fontSize={Number(theme.typography.body1.fontSize)}
           />
-        </Group>
-        <Text
-          text={dimension.width + 'x' + dimension.height}
-          x={imageWidth / 2 - 20}
-          y={imageHeight + 10}
-          fontFamily={theme.typography.fontFamily}
-          fontSize={Number(theme.typography.body1.fontSize)}
-        />
-      </>
-    </Group>
+        </>
+      </Group>
+    </>
   );
 };
 

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -158,8 +158,8 @@ const CanvasFrame = (props: Props) => {
   const imageRef = useRef<Konva.Image>(null);
   const transformRef = useRef<Konva.Transformer>(null);
   const [size, setSize] = useState<{ width: number; height: number }>({
-    width: imageWidth,
-    height: imageHeight,
+    width: dimension.width,
+    height: dimension.height,
   });
 
   useEffect(() => {
@@ -179,28 +179,51 @@ const CanvasFrame = (props: Props) => {
 
   const [imagePos, setImagePos] = useState({ x: 50, y: 50 });
 
-  const allFrameSizes = [
-    {
-      width: 21 * multiplyValue * scaleFactor,
-      height: 30 * multiplyValue * scaleFactor,
-    },
-    {
-      width: 30 * multiplyValue * scaleFactor,
-      height: 40 * multiplyValue * scaleFactor,
-    },
-    {
-      width: 40 * multiplyValue * scaleFactor,
-      height: 50 * multiplyValue * scaleFactor,
-    },
-    {
-      width: 50 * multiplyValue * scaleFactor,
-      height: 70 * multiplyValue * scaleFactor,
-    },
-    {
-      width: 70 * multiplyValue * scaleFactor,
-      height: 100 * multiplyValue * scaleFactor,
-    },
-  ];
+  const allFrameSizes = props.item.poster.isPortrait
+    ? [
+        {
+          width: 21 * multiplyValue * scaleFactor,
+          height: 30 * multiplyValue * scaleFactor,
+        },
+        {
+          width: 30 * multiplyValue * scaleFactor,
+          height: 40 * multiplyValue * scaleFactor,
+        },
+        {
+          width: 40 * multiplyValue * scaleFactor,
+          height: 50 * multiplyValue * scaleFactor,
+        },
+        {
+          width: 50 * multiplyValue * scaleFactor,
+          height: 70 * multiplyValue * scaleFactor,
+        },
+        {
+          width: 70 * multiplyValue * scaleFactor,
+          height: 100 * multiplyValue * scaleFactor,
+        },
+      ]
+    : [
+        {
+          height: 21 * multiplyValue * scaleFactor,
+          width: 30 * multiplyValue * scaleFactor,
+        },
+        {
+          height: 30 * multiplyValue * scaleFactor,
+          width: 40 * multiplyValue * scaleFactor,
+        },
+        {
+          height: 40 * multiplyValue * scaleFactor,
+          width: 50 * multiplyValue * scaleFactor,
+        },
+        {
+          height: 50 * multiplyValue * scaleFactor,
+          width: 70 * multiplyValue * scaleFactor,
+        },
+        {
+          height: 70 * multiplyValue * scaleFactor,
+          width: 100 * multiplyValue * scaleFactor,
+        },
+      ];
 
   const handleTransformEnd = () => {
     const node = imageRef.current;
@@ -400,8 +423,8 @@ const CanvasFrame = (props: Props) => {
       <Image
         image={poster}
         alt="cola"
-        width={50 * multiplyValue * scaleFactor}
-        height={70 * multiplyValue * scaleFactor}
+        width={imageWidth}
+        height={imageHeight}
         ref={imageRef}
         draggable
         onDragEnd={(e) => {

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -24,12 +24,6 @@ interface Props {
   selectShape: Dispatch<SetStateAction<number | null>>;
   isSelected: boolean;
 }
-interface TransformEvent extends Event {
-  scaleX: number;
-  scaleY: number;
-  clientX: number;
-  clientY: number;
-}
 
 // TODO: what is missing here is the frame scaling and previous position
 // but for previous position i guess we are only able to do it once we have the canvas object
@@ -69,9 +63,7 @@ const CanvasFrame = (props: Props) => {
   const multiplyValue = 20;
 
   let imageAspectRatio,
-    scaleFactor = 1,
-    imageWidth = 1,
-    imageHeight = 1;
+    scaleFactor = 1;
   if (poster && props.imageScale.scaleX && props.imageScale.scaleY) {
     imageAspectRatio =
       ((dimension.width * multiplyValue) / dimension.height) * multiplyValue;
@@ -81,16 +73,7 @@ const CanvasFrame = (props: Props) => {
     } else {
       scaleFactor = Math.min(props.imageScale.scaleX, props.imageScale.scaleY);
     }
-    if (props.item.poster.isPortrait) {
-      imageWidth = dimension.width * multiplyValue * scaleFactor;
-      imageHeight = dimension.height * multiplyValue * scaleFactor;
-    } else {
-      imageWidth = dimension.height * multiplyValue * scaleFactor;
-      imageHeight = dimension.width * multiplyValue * scaleFactor;
-    }
   }
-
-  const groupRef = useRef<Konva.Group>(null);
   const imageRef = useRef<Konva.Rect>(null);
   const transformRef = useRef<Konva.Transformer>(null);
   const [size, setSize] = useState<{ width: number; height: number }>({
@@ -400,12 +383,7 @@ const CanvasFrame = (props: Props) => {
             />
           </Group>
           <Text
-            text={
-              size.width +
-              'x' +
-              size.height +
-              `${props.isSelected ? 'selected' : 'not selected'}`
-            }
+            text={size.width + 'x' + size.height}
             x={scaledSizes.width / 2 - 20}
             y={scaledSizes.height + 10}
             fontFamily={theme.typography.fontFamily}

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -51,8 +51,8 @@ const CanvasFrame = (props: Props) => {
     'https://firebasestorage.googleapis.com/v0/b/blueprint-298a2.appspot.com/o/frames%2Fwalnut-surface.jpeg?alt=media&token=e0224afc-7b60-414e-8922-63804d3f7f4c'
   );
 
-  const [frameBorder, setFrameBorder] = useState(0);
-  const [passepartout, setPassepartout] = useState(0);
+  const [frameBorder, setFrameBorder] = useState(20);
+  const [passepartout, setPassepartout] = useState(20);
 
   const frameColor = () => {
     if (match[0].category.includes('Wooden')) {
@@ -90,49 +90,12 @@ const CanvasFrame = (props: Props) => {
     }
   }
 
-  const handleDragEnd = (e: Konva.KonvaEventObject<DragEvent>) => {
-    setElementPos({
-      x: e.target.x(),
-      y: e.target.y(),
-    });
-    props.selectShape(props.index);
-  };
-
-  const { width, height, x, y } = props.bg;
-  const handleDrag = (pos: Konva.Vector2d) => {
-    const newX = Math.max(x!, Math.min(pos.x, x! + width - scaledSizes.width!));
-    const newY = Math.max(
-      y!,
-      Math.min(pos.y, y! + height - scaledSizes.height!)
-    );
-    return {
-      x: newX,
-      y: newY,
-    };
-  };
   const groupRef = useRef<Konva.Group>(null);
-  const trRef = useRef<Konva.Transformer>(null);
-
-  useEffect(() => {
-    if (props.isSelected && trRef.current && groupRef.current) {
-      trRef.current.nodes([groupRef.current]);
-      trRef.current.getLayer()!.batchDraw();
-      trRef.current.centeredScaling(true);
-      // trRef.current.enabledAnchors([
-      //   'top-left',
-      //   'top-right',
-      //   'bottom-left',
-      //   'bottom-right',
-      // ]);
-      trRef.current.flipEnabled(false);
-    }
-  }, [props.isSelected]);
-
   const imageRef = useRef<Konva.Rect>(null);
   const transformRef = useRef<Konva.Transformer>(null);
   const [size, setSize] = useState<{ width: number; height: number }>({
-    width: dimension.width,
-    height: dimension.height,
+    width: props.item.poster.isPortrait ? dimension.width : dimension.height,
+    height: props.item.poster.isPortrait ? dimension.height : dimension.width,
   });
 
   useEffect(() => {
@@ -149,8 +112,6 @@ const CanvasFrame = (props: Props) => {
       transformRef.current.flipEnabled(false);
     }
   }, [props.isSelected]);
-
-  const [imagePos, setImagePos] = useState({ x: 50, y: 50 });
 
   const allFrameSizes = props.item.poster.isPortrait
     ? [
@@ -225,7 +186,9 @@ const CanvasFrame = (props: Props) => {
         : (frameBorder = 10);
       return frameBorder * 5 * scaleFactor;
     });
+  }, [size, scaleFactor, dimension, props]);
 
+  useEffect(() => {
     setPassepartout(() => {
       let passepartout = 0;
       let currentSize = props.item.poster.isPortrait
@@ -243,10 +206,28 @@ const CanvasFrame = (props: Props) => {
 
       return passepartout * 5 * scaleFactor + frameBorder;
     });
+  }, [frameBorder, scaleFactor, dimension, props, size]);
 
-    console.log(scaleFactor);
-  }, [size, scaleFactor, dimension]);
+  const handleDragEnd = (e: Konva.KonvaEventObject<DragEvent>) => {
+    setElementPos({
+      x: e.target.x(),
+      y: e.target.y(),
+    });
+    props.selectShape(props.index);
+  };
 
+  const handleDrag = (pos: Konva.Vector2d) => {
+    const { width, height, x, y } = props.bg;
+    const newX = Math.max(x!, Math.min(pos.x, x! + width - scaledSizes.width!));
+    const newY = Math.max(
+      y!,
+      Math.min(pos.y, y! + height - scaledSizes.height!)
+    );
+    return {
+      x: newX,
+      y: newY,
+    };
+  };
   return (
     <>
       <Rect

--- a/components/shared/CanvasFrame.tsx
+++ b/components/shared/CanvasFrame.tsx
@@ -109,7 +109,6 @@ const CanvasFrame = (props: Props) => {
         'bottom-left',
         'bottom-right',
       ]);
-      transformRef.current.flipEnabled(false);
     }
   }, [props.isSelected]);
 
@@ -245,7 +244,6 @@ const CanvasFrame = (props: Props) => {
         draggable
         onDragStart={() => props.selectShape(null)}
         onDragEnd={handleDragEnd}
-        ref={groupRef}
         onClick={() => props.selectShape(props.index)}
       >
         <>
@@ -421,6 +419,7 @@ const CanvasFrame = (props: Props) => {
           ref={transformRef}
           rotateEnabled={false}
           keepRatio={false}
+          flipEnabled={false}
           onMouseUp={() => {
             const node = imageRef.current;
             if (!node) return;
@@ -473,8 +472,8 @@ const CanvasFrame = (props: Props) => {
               return {
                 x: bbox.x,
                 y: bbox.y,
-                width: nextSize.width,
-                height: nextSize.height,
+                width: scaledSizes.width,
+                height: scaledSizes.height,
                 rotation: rotation, // add the rotation property
               };
             }

--- a/components/sidebar/PosterSectionDetails.tsx
+++ b/components/sidebar/PosterSectionDetails.tsx
@@ -184,6 +184,7 @@ const PosterSectionDetails = () => {
                   id: p.id!,
                   image: p.image,
                   isPortrait: p.orientation === 'Portrait' ? true : false,
+                  sizes: p.sizes,
                 });
                 setAnchorSidebar(false);
               }}

--- a/components/types.ts
+++ b/components/types.ts
@@ -34,6 +34,7 @@ export interface CanvasPoster {
   id: string;
   image: string;
   isPortrait: boolean | undefined;
+  sizes: Dimension[];
 }
 
 export interface Poster {

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -39,7 +39,7 @@ export const CanvasContext = createContext<CanvasContextValue>({
   setBackground: () => '',
   withPassepartout: true,
   setWithPassepartout: () => true,
-  poster: { id: '', image: '', isPortrait: undefined },
+  poster: { id: '', image: '', isPortrait: undefined, sizes: [] },
   setPoster: () => '',
   posterOrientation: '',
   setPosterOrientation: () => '',
@@ -59,6 +59,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     id: '',
     image: '',
     isPortrait: undefined,
+    sizes: [],
   });
   const [posterOrientation, setPosterOrientation] = useState<string>('');
   const [frameSet, setFrameSet] = useState<CanvasFrameSet>({
@@ -69,7 +70,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [frameSets, setFrameSets] = useState<CanvasFrameSet[]>([]);
   const [item, setItem] = useState<CanvasItem>({
     frame: frameSet,
-    poster: { id: '', image: '', isPortrait: undefined },
+    poster: { id: '', image: '', isPortrait: undefined, sizes: [] },
     withPassepartout: withPassepartout,
     position: { x: 0, y: 0 },
   });
@@ -95,11 +96,11 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
       /** reset all states below as the item has been pushed to the items array state */
       setItem({
         frame: { id: '', title: '', size: '' },
-        poster: { id: '', image: '', isPortrait: undefined },
+        poster: { id: '', image: '', isPortrait: undefined, sizes: [] },
         withPassepartout: true,
         position: { x: 0, y: 0 },
       });
-      setPoster({ id: '', image: '', isPortrait: undefined });
+      setPoster({ id: '', image: '', isPortrait: undefined, sizes: [] });
       setFrameSet({ id: '', size: '', title: '' });
       setWithPassepartout(true);
       setIsEditingFrame(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-config-next": "13.0.7",
         "firebase": "^9.14.0",
         "konva": "^8.3.14",
+        "lodash": "^4.17.21",
         "next": "13.0.7",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-next": "13.0.7",
     "firebase": "^9.14.0",
     "konva": "^8.3.14",
+    "lodash": "^4.17.21",
     "next": "13.0.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
- Resizing a frame now works. 
- Border changes size when user is resizing the frame.
- Measurements only visible when resizing.
- Fixed the CanvasPoster type so I could also get the sizes of the poster.
- Resizing 'snaps' to the closest available size of the poster.
- If poster is only available in one size, resizing is disabled.

**TODO:
When a user resizes the frame, nothing is updated in the canvas context. Later when we implement the saving function we want to save the new sizes id the user has resized a frame.  In other words:  call setFrameSet to change the frame size whenever the user has resized it. I wasn't sure of the logic you had written for this so I added a new issue for it.**

**TODO: We might also want the user to get different options when clicking a frame? Since now if a user clicks the frame it both toggles its canvas resizing thing and also opens the sidebar. Maybe we want the user to click the frame and have two options - either edit the frame in the sidebar or resize it in the canvas.**