### PR TITLE
#104, #108 and #102 bug fix for user upload form

### DIFF
--- a/components/helper.ts
+++ b/components/helper.ts
@@ -51,7 +51,10 @@ export const compareUserAndCreatedAt = (
   b: Poster | Background
 ) => {
   if (a.user || b.user) {
-    if (a.createdAt! > b.createdAt!) return -1;
+    if (
+      Date.parse(a.createdAt!.toString()) > Date.parse(b.createdAt!.toString())
+    )
+      return -1;
     return 1;
   }
   return 0;

--- a/components/imageUpload/ImageUploadForm.tsx
+++ b/components/imageUpload/ImageUploadForm.tsx
@@ -67,7 +67,7 @@ const ImageUploadForm = (props: Props) => {
               onChange={(event) => handleImageChange(event)}
             />
           </Button>
-          {file && !imageError && preview && (
+          {file && imageError.length < 1 && preview && (
             <Button
               type="submit"
               sx={{

--- a/components/imageUpload/ImageUploadForm.tsx
+++ b/components/imageUpload/ImageUploadForm.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, FormControl, Typography } from '@mui/material';
 import Image from 'next/image';
-import { useEffect } from 'react';
 import { useUpload } from '../../context/UploadContext';
 import { theme } from '../theme';
 
@@ -11,16 +10,6 @@ interface Props {
 const ImageUploadForm = (props: Props) => {
   const { preview, setPreview, handleImageChange, file, imageError, submit } =
     useUpload();
-
-  /* create a preview whenever file is changed */
-  useEffect(() => {
-    if (!file) return setPreview(undefined);
-
-    const objectUrl = URL.createObjectURL(file);
-    setPreview(objectUrl);
-
-    return () => URL.revokeObjectURL(objectUrl);
-  }, [file, setPreview]);
 
   return (
     <Box
@@ -64,7 +53,7 @@ const ImageUploadForm = (props: Props) => {
               hidden
               type="file"
               accept="image/*"
-              onChange={(event) => handleImageChange(event)}
+              onChange={(e) => handleImageChange(e)}
             />
           </Button>
           {file && imageError.length < 1 && preview && (

--- a/components/imageUpload/ImageUploadForm.tsx
+++ b/components/imageUpload/ImageUploadForm.tsx
@@ -3,20 +3,23 @@ import Image from 'next/image';
 import { useUpload } from '../../context/UploadContext';
 import { theme } from '../theme';
 
-interface Props {
-  for: 'Poster' | 'Background';
-}
-
-const ImageUploadForm = (props: Props) => {
-  const { preview, setPreview, handleImageChange, file, imageError, submit } =
-    useUpload();
+const ImageUploadForm = () => {
+  const {
+    preview,
+    setPreview,
+    handleImageChange,
+    file,
+    imageError,
+    submit,
+    uploadOption,
+  } = useUpload();
 
   return (
     <Box
       component="form"
       onSubmit={(e) => {
         e.preventDefault();
-        submit(props.for);
+        submit();
       }}
       sx={{ display: 'flex', flexDirection: 'column' }}
     >

--- a/components/imageUpload/ImageUploadModal.tsx
+++ b/components/imageUpload/ImageUploadModal.tsx
@@ -11,22 +11,21 @@ import { IconCheck, IconChevronRight, IconX } from '@tabler/icons';
 import { useUpload } from '../../context/UploadContext';
 import ImageUploadForm from './ImageUploadForm';
 
-interface Props {
-  for: 'Poster' | 'Background';
-}
-
-const ImageUploadModal = (props: Props) => {
+const ImageUploadModal = () => {
   const {
     setOpenUploadModal,
     openUploadModal,
     file,
     imageError,
     resetAllUploadStates,
+    uploadOption,
+    setUploadOption,
   } = useUpload();
 
   /* Closes modal  */
   const handleClose = () => {
     setOpenUploadModal(false);
+    setUploadOption(undefined);
     resetAllUploadStates();
   };
 
@@ -50,8 +49,8 @@ const ImageUploadModal = (props: Props) => {
 
   /* Check props and display the correct instuctions */
   const getInstructions = () => {
-    if (props.for === 'Background') return backgroundInstructions;
-    if (props.for === 'Poster') return posterInstructions;
+    if (uploadOption === 'Background') return backgroundInstructions;
+    if (uploadOption === 'Poster') return posterInstructions;
   };
 
   return (
@@ -86,7 +85,7 @@ const ImageUploadModal = (props: Props) => {
             }}
           />
           <Typography component="h3" variant="subtitle2" pb={1}>
-            Upload My Own {props.for}
+            Upload My Own {uploadOption}
           </Typography>
           <List sx={{ m: 'auto', width: 250 }}>
             <Typography
@@ -124,7 +123,7 @@ const ImageUploadModal = (props: Props) => {
               </ListItem>
             ))}
           </List>
-          <ImageUploadForm for={props.for} />
+          <ImageUploadForm />
         </Box>
       </Box>
     </Modal>

--- a/components/imageUpload/ImageUploadModal.tsx
+++ b/components/imageUpload/ImageUploadModal.tsx
@@ -20,16 +20,14 @@ const ImageUploadModal = (props: Props) => {
     setOpenUploadModal,
     openUploadModal,
     file,
-    setFile,
     imageError,
-    setImageError,
+    resetAllUploadStates,
   } = useUpload();
 
   /* Closes modal  */
   const handleClose = () => {
     setOpenUploadModal(false);
-    setFile(undefined);
-    setImageError([]);
+    resetAllUploadStates();
   };
 
   const backgroundInstructions = [

--- a/components/imageUpload/ImageUploadModal.tsx
+++ b/components/imageUpload/ImageUploadModal.tsx
@@ -103,7 +103,7 @@ const ImageUploadModal = (props: Props) => {
                 <ListItemIcon sx={{ minWidth: 20 }}>
                   {file && imageError?.includes(instruction.type) ? (
                     <IconX size={12} color="#E23A22" />
-                  ) : (file && !imageError) ||
+                  ) : (file && imageError.length < 1) ||
                     (file && imageError?.indexOf(instruction.type) === -1) ? (
                     <IconCheck size={12} color="#3086B7" />
                   ) : (

--- a/components/imageUpload/UploadButton.tsx
+++ b/components/imageUpload/UploadButton.tsx
@@ -10,11 +10,15 @@ interface Props {
 }
 
 const UploadButton = (props: Props) => {
-  const { setOpenUploadModal } = useUpload();
+  const { setOpenUploadModal, setUploadOption } = useUpload();
   const { allPosters, allBackgrounds } = useSidebar();
   const { currentUser } = useUser();
 
-  const handleClick = () => setOpenUploadModal(true);
+  const handleClick = () => {
+    if (props.for === 'Poster') setUploadOption('Poster');
+    if (props.for === 'Background') setUploadOption('Background');
+    setOpenUploadModal(true);
+  };
 
   /* Check how many backgrounds and posters the user has uploaded based on props */
   const checkNoOfUpload = () => {
@@ -49,7 +53,7 @@ const UploadButton = (props: Props) => {
         </Typography>
       )}
 
-      <ImageUploadModal for={props.for} />
+      <ImageUploadModal />
     </Box>
   ) : (
     <Box width="100%" mt={2} sx={{ display: 'flex', placeContent: 'center' }}>

--- a/components/types.ts
+++ b/components/types.ts
@@ -40,8 +40,8 @@ export interface CanvasPoster {
 }
 
 export interface Poster {
-  categories: string[];
-  createdAt?: typeof posterCategories;
+  categories: typeof posterCategories;
+  createdAt?: Timestamp;
   image: string;
   id?: string;
   title: string;

--- a/context/SidebarContext.tsx
+++ b/context/SidebarContext.tsx
@@ -1,9 +1,11 @@
+import { collection, getDocs } from 'firebase/firestore';
 import {
   createContext,
   Dispatch,
   FC,
   PropsWithChildren,
   SetStateAction,
+  useCallback,
   useContext,
   useState,
 } from 'react';
@@ -17,6 +19,7 @@ import {
   Frame,
   Poster,
 } from '../components/types';
+import { db } from '../firebase/firebaseConfig';
 import { sidebarSections } from '../lib/valSchemas';
 
 interface SidebarContextValue {
@@ -88,6 +91,8 @@ interface SidebarContextValue {
   setPosterOrientation: Dispatch<SetStateAction<string>>;
   frameSet: CanvasFrameSet;
   setFrameSet: Dispatch<SetStateAction<CanvasFrameSet>>;
+  getAllBackgrounds: () => void;
+  getAllPosters: () => void;
 }
 
 export const SidebarContext = createContext<SidebarContextValue>({
@@ -137,6 +142,8 @@ export const SidebarContext = createContext<SidebarContextValue>({
   setPosterOrientation: () => '',
   frameSet: { id: '', title: '', size: '' },
   setFrameSet: () => {},
+  getAllBackgrounds: () => {},
+  getAllPosters: () => {},
 });
 
 const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -207,6 +214,30 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
     setPosterOrientation('');
   };
 
+  const getAllBackgrounds = useCallback(async () => {
+    const backgroundsCollectionRef = collection(db, 'backgrounds');
+    const backgroundData = await getDocs(backgroundsCollectionRef);
+    setAllBackgrounds(
+      backgroundData.docs.map((doc) => ({
+        ...(doc.data() as Background),
+        id: doc.id,
+        createdAt: doc.data().createdAt.toDate().toDateString(),
+      }))
+    );
+  }, [setAllBackgrounds]);
+
+  const getAllPosters = useCallback(async () => {
+    const postersCollectionRef = collection(db, 'posters');
+    const posterData = await getDocs(postersCollectionRef);
+    setAllPosters(
+      posterData.docs.map((doc) => ({
+        ...(doc.data() as Poster),
+        id: doc.id,
+        createdAt: doc.data().createdAt.toDate().toDateString(),
+      }))
+    );
+  }, [setAllPosters]);
+
   return (
     <SidebarContext.Provider
       value={{
@@ -238,6 +269,8 @@ const SidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
         setPosterOrientation,
         frameSet,
         setFrameSet,
+        getAllBackgrounds,
+        getAllPosters,
       }}
     >
       {children}

--- a/context/UploadContext.tsx
+++ b/context/UploadContext.tsx
@@ -27,6 +27,7 @@ interface UploadContextValue {
   handleImageChange: (event: ChangeEvent) => void;
   imageError: string[];
   setImageError: Dispatch<SetStateAction<string[]>>;
+  resetAllUploadStates: () => void;
 }
 
 export const UploadContext = createContext<UploadContextValue>({
@@ -40,6 +41,7 @@ export const UploadContext = createContext<UploadContextValue>({
   handleImageChange: () => {},
   imageError: [],
   setImageError: () => [],
+  resetAllUploadStates: () => {},
 });
 
 const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -49,21 +51,9 @@ const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [preview, setPreview] = useState<string>();
   const [file, setFile] = useState<File | undefined>(undefined);
   const [imageError, setImageError] = useState<string[]>([]);
-
   const [imgDimension, setImgDimension] = useState<
     { width: number; height: number } | undefined
   >();
-
-  // /* create a preview whenever file is changed */
-  // useEffect(() => {
-  //   if (!file) return setPreview(undefined);
-
-  //   const objectUrl = URL.createObjectURL(file);
-  //   setPreview(objectUrl);
-  //   console.log('called use Effect');
-
-  //   return () => URL.revokeObjectURL(objectUrl);
-  // }, [file, setPreview]);
 
   /* Handle form submission */
   const submit = (imageFor: string) => {
@@ -148,8 +138,7 @@ const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
             message: `${imageFor} ${file!.name} is added`,
             type: 'Success',
           });
-          setFile(undefined);
-          setImageError([]);
+          resetAllUploadStates();
         })
         .catch((error) => {
           setNotification({
@@ -163,10 +152,7 @@ const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
   /* Check if image meets the requirements */
   const handleImageChange = async (event: ChangeEvent) => {
-    // clear all states
-    setFile(undefined);
-    setImgDimension(undefined);
-    setImageError([]);
+    resetAllUploadStates();
 
     // set current file, return if no file
     const target = event.target as HTMLInputElement;
@@ -204,6 +190,14 @@ const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
     return acceptedImageTypes.includes(file['type']);
   };
 
+  /* Reset all states in the upload context except for openModal */
+  const resetAllUploadStates = () => {
+    setFile(undefined);
+    setPreview(undefined);
+    setImgDimension(undefined);
+    setImageError([]);
+  };
+
   return (
     <UploadContext.Provider
       value={{
@@ -217,6 +211,7 @@ const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
         handleImageChange,
         imageError,
         setImageError,
+        resetAllUploadStates,
       }}
     >
       {children}

--- a/context/UploadContext.tsx
+++ b/context/UploadContext.tsx
@@ -14,6 +14,7 @@ import {
 import { getImageSize } from 'react-image-size';
 import { db, storage } from '../firebase/firebaseConfig';
 import { useNotification } from './NotificationContext';
+import { useSidebar } from './SidebarContext';
 import { useUser } from './UserContext';
 
 interface UploadContextValue {
@@ -52,6 +53,7 @@ export const UploadContext = createContext<UploadContextValue>({
 
 const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const { currentUser } = useUser();
+  const { getAllBackgrounds, getAllPosters } = useSidebar();
   const { setNotification } = useNotification();
   const [openUploadModal, setOpenUploadModal] = useState<boolean>(false);
   const [preview, setPreview] = useState<string>();
@@ -142,6 +144,7 @@ const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
       await addDoc(dbCollectionRef, newImage)
         .then(() => {
+          uploadOption === 'Poster' ? getAllPosters() : getAllBackgrounds();
           setOpenUploadModal(false);
           setUploadOption(undefined);
           setNotification({
@@ -157,7 +160,15 @@ const UploadContextProvider: FC<PropsWithChildren> = ({ children }) => {
           });
         });
     },
-    [currentUser, file, imgDimension, setNotification, uploadOption]
+    [
+      currentUser,
+      file,
+      getAllBackgrounds,
+      getAllPosters,
+      imgDimension,
+      setNotification,
+      uploadOption,
+    ]
   );
 
   /* Check if image meets the requirements */

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.41.0",
+        "react-image-size": "^2.0.0",
         "react-konva": "^18.2.3",
         "typescript": "4.9.4",
         "use-image": "^1.1.0",
@@ -4501,6 +4502,15 @@
         "react": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-image-size": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-image-size/-/react-image-size-2.0.0.tgz",
+      "integrity": "sha512-6wjalqkkRKnU8VslTOUPooP954lvD9G7zSo2zu9S3vvboN4WRDfFmnfm291Pl5wcXroobYrcVpywP8ijshMmeg==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -8496,6 +8506,12 @@
       "version": "7.41.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.2.tgz",
       "integrity": "sha512-Uz5kNlfkEZve0sr5y2LsxPDGN3eNDjjKb1XJgand1E5Ay0S3zWo8YcJQNGu88/Zs6JaFnrJqTXbSr6B2q7wllA==",
+      "requires": {}
+    },
+    "react-image-size": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-image-size/-/react-image-size-2.0.0.tgz",
+      "integrity": "sha512-6wjalqkkRKnU8VslTOUPooP954lvD9G7zSo2zu9S3vvboN4WRDfFmnfm291Pl5wcXroobYrcVpywP8ijshMmeg==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.41.0",
+    "react-image-size": "^2.0.0",
     "react-konva": "^18.2.3",
     "typescript": "4.9.4",
     "use-image": "^1.1.0",


### PR DESCRIPTION
## Describe your changes
- Show "upload" button when there is no length in the imageError state (fixed #107)
- Rewrote the handleChange function to fix #104. Removed the useEffect and put the setPreview and setFile inside the handleChange for simplicity 
- Fixed #108 by removing the props with a state from context to control which modal to show for image upload
- add getAllBackgrounds and getAllPosters functions and call it after adding a new image to fix #102

**What I suggest testing when you review this PR in addition to the upload function:** 
- [ ] The correct modal should be shown when you click the "upload your own" button in poster/background section (the modal title "poster" / "background" could tell)
- [ ] Try choosing different image to fail one or some or all image requirements
- [ ] The upload button in the modal should only be shown when all requirements are met 
- [ ] Upload 3 images in the same section and then check if the upload button is disabled


## Issue ticket number and link
#104, #107, #108 and #102