### PR TITLE
114 if user has canvas in db use it as initial canvasstate

### DIFF
--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -11,6 +11,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { Canvas, CanvasItem } from '../components/types';
 import { useSidebar } from './SidebarContext';
+import { useUser } from './UserContext';
 
 interface CanvasContextValue {
   allCanvases: Canvas[];
@@ -53,6 +54,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     frameSet,
     withPassepartout,
   } = useSidebar();
+  const { currentUser } = useUser();
 
   const [allCanvases, setAllCanvases] = useState<Canvas[]>([]);
   const [canvas, setCanvas] = useState<Canvas>(() => {
@@ -69,6 +71,16 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
           };
     }
   });
+
+  useEffect(() => {
+    if (currentUser) {
+      if (allCanvases.find((item) => item.user === currentUser.uid)) {
+        //right now this solution only supports one canvas/user.
+        setCanvas(allCanvases.find((item) => item.user === currentUser.uid)!);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentUser]);
 
   const setBackground = (background: {
     image: string;

--- a/context/SaveContext.tsx
+++ b/context/SaveContext.tsx
@@ -4,7 +4,7 @@ import {
   doc,
   getDocs,
   serverTimestamp,
-  updateDoc,
+  setDoc,
 } from 'firebase/firestore';
 import {
   createContext,
@@ -55,11 +55,19 @@ const SaveContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
       if (canvases && canvases.some((item) => item.id === canvas.id)) {
         // logic for updating
+
+        const bg = JSON.parse(localStorage.getItem('canvas')!).background;
+        const items = JSON.parse(localStorage.getItem('canvas')!).items;
         const currentCanvasRef = doc(db, 'canvas', canvas.id!);
-        await updateDoc(currentCanvasRef, {
-          ...canvas,
-          updatedAt: serverTimestamp(),
-        })
+        await setDoc(
+          currentCanvasRef,
+          {
+            background: bg,
+            items: items,
+            updatedAt: serverTimestamp(),
+          },
+          { merge: true }
+        )
           .then(async () => {
             setNotification({
               message: `${title} has been updated`,
@@ -80,14 +88,12 @@ const SaveContextProvider: FC<PropsWithChildren> = ({ children }) => {
               type: 'Warning',
             });
           });
-
-        canvases.find((item) => item.id === canvas.id);
       } else {
         await addDoc(dbCollectionRef, {
           ...canvas,
           title: title,
           user: currentUser.uid,
-          createdAt: canvas.createdAt || serverTimestamp(),
+          createdAt: serverTimestamp(),
           updatedAt: serverTimestamp(),
         })
           .then(async (canvasFromDb) => {
@@ -127,11 +133,6 @@ const SaveContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const saveCanvasToDataBase = (title: string) => {
     if (currentUser) {
-      setCanvas({
-        ...canvas,
-        title: title,
-        user: currentUser.uid,
-      });
       saveToDataBase(title);
     } else
       setNotification({


### PR DESCRIPTION
**Fixes the following**

- [ ] Before non-logged in users would also be faced with the prompt warning when closing the window, this is fixed now.
- [ ] Initial canvas state for logged in users now has the following priority **canvas in database?** else **canvas in local storage?** else **empty**

**The branch before always updated the database one step behind the actual state. I did not notice this until now that I actually used the canvas from the database as initial state. The reason was because the local canvas variable was one step behind in the update function, so now it updates from localstorage instead, which is always up to date.**

**FURTHER FIXES**

Once/if we implement the support of having more than one canvas in the database we will have to update the useEffect that sets the canvasState. Now, since the users only can have one, it searches the database for a canvas that has the users own id in it. If we wanna be able to have multiple canvases we should search for the user id and select the **latest one** that the user edited. We can check this with the updatedAt variable.