### PR TITLE
120 user uploaded bgs should have a slider

### DIFF
--- a/components/canvas/Canvas.tsx
+++ b/components/canvas/Canvas.tsx
@@ -117,7 +117,7 @@ const Canvas = () => {
           sx={{
             width: XsScreen ? 195 : 295,
             position: 'absolute',
-            bottom: 10,
+            bottom: 0,
             left: XsScreen ? 'calc(50% - 127.5px)' : 'calc(50% - 187.5px)',
             zIndex: 10,
             overflow: 'hidden',
@@ -138,6 +138,7 @@ const Canvas = () => {
             defaultValue={30}
             color="primary"
             min={10}
+            max={300}
             step={5}
           />
           <Tooltip title="Drag slider to resize frames">

--- a/components/canvas/Canvas.tsx
+++ b/components/canvas/Canvas.tsx
@@ -1,14 +1,15 @@
-import { Container } from '@mui/material';
+import { Box, Container, Slider, useMediaQuery } from '@mui/material';
 import Konva from 'konva';
 import { useEffect, useRef, useState } from 'react';
 import { Group, Image, Layer, Stage } from 'react-konva';
 import useImage from 'use-image';
 import { useCanvas } from '../../context/CanvasContext';
 import { useSidebar } from '../../context/SidebarContext';
+import { theme } from '../theme';
 import CanvasItem from './CanvasItem';
 
 const Canvas = () => {
-  const { canvas, getBackground } = useCanvas();
+  const { canvas, getBackground, setBackground } = useCanvas();
   const { endEditMode } = useSidebar();
   const stageCanvasRef = useRef<HTMLDivElement>(null);
 
@@ -57,6 +58,7 @@ const Canvas = () => {
     x = (dimensions.width - canvasBackground!.width * scale) / 2;
     y = (dimensions.height - canvasBackground!.height * scale) / 2;
   }
+  const XsScreen = useMediaQuery(theme.breakpoints.down(485));
 
   const checkDeselect = (
     e: Konva.KonvaEventObject<MouseEvent> | Konva.KonvaEventObject<TouchEvent>
@@ -69,49 +71,108 @@ const Canvas = () => {
       endEditMode();
     }
   };
+  const [value, setValue] = useState<number>(3.5);
+
+  const handleChange = (event: Event, newValue: number | number[]) => {
+    if (
+      Math.round(((newValue as number) / 14.2857143) * 10) / 10 !==
+      canvas.background!.cmInPixels
+    ) {
+      if (canvas.background?.user) {
+        setBackground({
+          ...canvas.background!,
+          cmInPixels: Math.round(((newValue as number) / 14.2857143) * 10) / 10,
+        });
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (canvas.background) {
+      if (canvas.background.cmInPixels) {
+        if (canvas.background.user) {
+          if (
+            Math.round((value / 14.2857143) * 10) / 10 !==
+            canvas.background.cmInPixels
+          ) {
+            setValue(Math.round(canvas.background.cmInPixels * 14.2857143));
+          }
+        }
+      }
+    }
+  }, [canvas, value]);
 
   return (
-    <Container sx={{ height: '100%' }} ref={stageCanvasRef}>
-      <Stage
-        height={dimensions.height}
-        width={dimensions.width}
-        onMouseDown={checkDeselect}
-        onTouchStart={checkDeselect}
-      >
-        <Layer>
-          {canvasBackground && (
-            <Group scaleX={scale} scaleY={scale} x={x} y={y}>
-              <Image
-                height={canvasBackground.height}
-                width={canvasBackground.width}
-                alt="background"
-                image={canvasBackground}
-              />
-              {canvas.items.map(
-                (item) =>
-                  item.frame.id.length > 0 &&
-                  item.poster.id.length > 0 && (
-                    <CanvasItem
-                      key={item.id}
-                      item={item}
-                      pixelsInCm={canvas.background!.cmInPixels || 3.5}
-                      bg={{
-                        x,
-                        y,
-                        width: canvasBackground.width * scale,
-                        height: canvasBackground.height * scale,
-                        scale,
-                      }}
-                      selectShape={selectShape}
-                      isSelected={item.id === selectedId}
-                    />
-                  )
-              )}
-            </Group>
-          )}
-        </Layer>
-      </Stage>
-    </Container>
+    <>
+      {canvas.background && canvas.background.user && (
+        <Box
+          sx={{
+            width: XsScreen ? 195 : 295,
+            position: 'absolute',
+            bottom: 10,
+            left: XsScreen ? 'calc(50% - 127.5px)' : 'calc(50% - 187.5px)',
+            zIndex: 10,
+            overflow: 'hidden',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: 50,
+            px: XsScreen ? 2.5 : 5,
+          }}
+        >
+          <Slider
+            onChange={handleChange}
+            value={value}
+            aria-label="Size"
+            defaultValue={30}
+            color="primary"
+            min={10}
+            step={5}
+          />
+        </Box>
+      )}
+      <Container sx={{ height: '100%' }} ref={stageCanvasRef}>
+        <Stage
+          height={dimensions.height}
+          width={dimensions.width}
+          onMouseDown={checkDeselect}
+          onTouchStart={checkDeselect}
+        >
+          <Layer>
+            {canvasBackground && (
+              <Group scaleX={scale} scaleY={scale} x={x} y={y}>
+                <Image
+                  height={canvasBackground.height}
+                  width={canvasBackground.width}
+                  alt="background"
+                  image={canvasBackground}
+                />
+                {canvas.items.map(
+                  (item) =>
+                    item.frame.id.length > 0 &&
+                    item.poster.id.length > 0 && (
+                      <CanvasItem
+                        key={item.id}
+                        item={item}
+                        pixelsInCm={canvas.background!.cmInPixels || 3.5}
+                        bg={{
+                          x,
+                          y,
+                          width: canvasBackground.width * scale,
+                          height: canvasBackground.height * scale,
+                          scale,
+                        }}
+                        selectShape={selectShape}
+                        isSelected={item.id === selectedId}
+                      />
+                    )
+                )}
+              </Group>
+            )}
+          </Layer>
+        </Stage>
+      </Container>
+    </>
   );
 };
 

--- a/components/canvas/Canvas.tsx
+++ b/components/canvas/Canvas.tsx
@@ -1,4 +1,12 @@
-import { Box, Container, Slider, useMediaQuery } from '@mui/material';
+import {
+  Box,
+  Container,
+  IconButton,
+  Slider,
+  Tooltip,
+  useMediaQuery,
+} from '@mui/material';
+import { IconResize } from '@tabler/icons';
 import Konva from 'konva';
 import { useEffect, useRef, useState } from 'react';
 import { Group, Image, Layer, Stage } from 'react-konva';
@@ -118,17 +126,25 @@ const Canvas = () => {
             alignItems: 'center',
             height: 50,
             px: XsScreen ? 2.5 : 5,
+            columnGap: 2,
           }}
         >
           <Slider
+            size="small"
             onChange={handleChange}
             value={value}
-            aria-label="Size"
+            aria-label="Multiply size"
+            aria-valuetext={`${value} multiply size`}
             defaultValue={30}
             color="primary"
             min={10}
             step={5}
           />
+          <Tooltip title="Drag slider to resize frames">
+            <IconButton color="primary">
+              <IconResize size={30} strokeWidth={1.2} />
+            </IconButton>
+          </Tooltip>
         </Box>
       )}
       <Container sx={{ height: '100%' }} ref={stageCanvasRef}>

--- a/components/types.ts
+++ b/components/types.ts
@@ -63,7 +63,7 @@ export interface Canvas {
   user: string | undefined;
   createdAt?: FieldValue; // TODO: change. Optional for now as this is not what im working on in this issue
   updatedAt?: FieldValue; // TODO: change. Optional for now as this is not what im working on in this issue
-  background?: { image: string; cmInPixels?: number }; // TODO: put the correct type. Wille is working on this so i dont bother the type here
+  background?: Background; // TODO: put the correct type. Wille is working on this so i dont bother the type here
   items: CanvasItem[];
 }
 

--- a/context/CanvasContext.tsx
+++ b/context/CanvasContext.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { Canvas, CanvasItem } from '../components/types';
+import { Background, Canvas, CanvasItem } from '../components/types';
 import { useSidebar } from './SidebarContext';
 import { useUser } from './UserContext';
 
@@ -17,7 +17,7 @@ interface CanvasContextValue {
   allCanvases: Canvas[];
   setAllCanvases: Dispatch<SetStateAction<Canvas[]>>;
   canvas: Canvas;
-  setBackground: (background: { image: string; cmInPixels?: number }) => void;
+  setBackground: (background: Background) => void;
   getBackground: () =>
     | {
         image: string;
@@ -82,11 +82,7 @@ const CanvasContextProvider: FC<PropsWithChildren> = ({ children }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUser]);
 
-  const setBackground = (background: {
-    image: string;
-    cmInPixels?: number;
-  }) => {
-    const newCanvas = { ...canvas, background: background };
+  const setBackground = (background: Background) => {
     setCanvas({ ...canvas, background });
   };
 

--- a/context/SaveContext.tsx
+++ b/context/SaveContext.tsx
@@ -1,10 +1,11 @@
 import {
   addDoc,
   collection,
+  deleteField,
   doc,
   getDocs,
   serverTimestamp,
-  setDoc,
+  updateDoc,
 } from 'firebase/firestore';
 import {
   createContext,
@@ -59,15 +60,12 @@ const SaveContextProvider: FC<PropsWithChildren> = ({ children }) => {
         const bg = JSON.parse(localStorage.getItem('canvas')!).background;
         const items = JSON.parse(localStorage.getItem('canvas')!).items;
         const currentCanvasRef = doc(db, 'canvas', canvas.id!);
-        await setDoc(
-          currentCanvasRef,
-          {
-            background: bg,
-            items: items,
-            updatedAt: serverTimestamp(),
-          },
-          { merge: true }
-        )
+        await updateDoc(currentCanvasRef, {
+          background: bg,
+          items: items,
+          updatedAt: serverTimestamp(),
+          user: bg.user ? bg.user : deleteField(),
+        })
           .then(async () => {
             setNotification({
               message: `${title} has been updated`,

--- a/pages/canvas.tsx
+++ b/pages/canvas.tsx
@@ -77,7 +77,6 @@ const CanvasPage = ({
     if (allCanvases && canvas) {
       if (allCanvases.some((item) => item.id === canvas.id)) {
         const currentItem = allCanvases.find((item) => item.id === canvas.id);
-        console.log('db', currentItem?.background, 'ls', canvas.background);
         if (
           isEqual(currentItem!.background, canvas.background) &&
           isEqual(currentItem!.items, canvas.items)

--- a/pages/canvas.tsx
+++ b/pages/canvas.tsx
@@ -60,7 +60,7 @@ const CanvasPage = ({
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { setAllFrames, setAllBackgrounds, setAllPosters } = useSidebar();
   const { saveCanvasToDataBase } = useSave();
-  const { canvas, setAllCanvases, allCanvases } = useCanvas();
+  const { canvas, setAllCanvases, allCanvases, setBackground } = useCanvas();
   const { currentUser } = useUser();
 
   useEffect(
@@ -77,7 +77,7 @@ const CanvasPage = ({
     if (allCanvases && canvas) {
       if (allCanvases.some((item) => item.id === canvas.id)) {
         const currentItem = allCanvases.find((item) => item.id === canvas.id);
-
+        console.log('db', currentItem?.background, 'ls', canvas.background);
         if (
           isEqual(currentItem!.background, canvas.background) &&
           isEqual(currentItem!.items, canvas.items)
@@ -127,6 +127,7 @@ const CanvasPage = ({
   const handleEndSession = async () => {
     saveCanvasToDataBase(canvas.title!);
   };
+
   return (
     <>
       <Head>
@@ -142,7 +143,9 @@ const CanvasPage = ({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Canvas />
+      <>
+        <Canvas />
+      </>
     </>
   );
 };


### PR DESCRIPTION
**This fixes the following**

- User can now freely scale all frames on their uploaded backgrounds between 1-100 with a slider.
- Saves the changes to the canvas locally and the canvas in database.
- If a user saves, it also updates the cmInPixels value for the background in the background db collection.
- Next time they use the background the updated scale value (cmInPixels) will be used.

**Test the following**

- [x] Select back and fourth from uploaded backgrounds and normal backgrounds. Uploaded background should have slider, normal should not.
- [x] Put in some frames and scale using the slider. Frames should grow/shrink depending on value.
- [x] The frames should still be responsive after scaling. (They should shrink/grow when the background grows/shrinks.
- [ ] Save the canvas and see if the scale also saves when u reload the page.
- [x] If you have saved canvas and scale again, it should warn that the latest changes aren't saved when trying to close the window.
- [ ] When scaling and saving, check that the cmInPixels value update to the new value in the database.

**Future issues:**

- The slider div does not have a bg-color. Is it difficult to see if the uploaded bg is dark?
- Maybe we want to add more buttons down there? Like delete all frames, center them etc.